### PR TITLE
feat(admin): implement offices CRUD end-to-end (core + repo + API + t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ Cargo.lock
 **/*.swp
 .DS_Store
 tmp/
+SKILLS.md
+AGENTS.md
+.agents/
+AGENTS*.md

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 
 help:
 	@echo "Targets:"
-	@echo "  test      - cargo test --workspace"
+	@echo "  test      - cargo test (serialized output with summary)"
 	@echo "  fmt       - cargo fmt --all"
 	@echo "  clippy    - cargo clippy --workspace --all-targets --all-features"
 	@echo "  dev-api   - run hub API"
@@ -12,7 +12,39 @@ help:
 	@echo "  build-web - build SvelteKit"
 
 test:
-	cargo test --workspace -- --test-threads=1
+	@set -o pipefail; \
+	cargo test -- --test-threads=1 2>&1 \
+	| tee /dev/tty \
+	| rg '^test result:' \
+	| awk 'BEGIN{ \
+		esc=sprintf("%c",27); reset=esc"[0m"; bold=esc"[1m"; \
+		c_total=esc"[38;2;90;200;255m"; \
+		c_pass =esc"[38;2;80;220;140m"; \
+		c_fail =esc"[38;2;255;90;90m"; \
+		c_ign  =esc"[38;2;255;170;60m"; \
+		c_meas =esc"[38;2;170;140;255m"; \
+		c_filt =esc"[38;2;255;120;200m"; \
+	} \
+	{ \
+		for(i=1;i<=NF;i++){ \
+			if($$(i+1)=="passed;")   p+=$$i; \
+			if($$(i+1)=="failed;")   f+=$$i; \
+			if($$(i+1)=="ignored;")  ig+=$$i; \
+			if($$(i+1)=="measured;") m+=$$i; \
+			if($$(i+1)=="filtered")  fo+=$$i; \
+		} \
+	} \
+	END{ \
+		printf("\n\n"); \
+		printf("%s%s%sTOTAL:%s ", bold, c_total, bold, reset); \
+		printf("%s%s%d passed;%s ",  bold, c_pass, p+0,  reset); \
+		printf("%s%s%d failed;%s ",  bold, c_fail, f+0,  reset); \
+		printf("%s%s%d ignored;%s ", bold, c_ign,  ig+0, reset); \
+		printf("%s%s%d measured;%s ",bold, c_meas, m+0,  reset); \
+		printf("%s%s%d filtered out;%s\n", bold, c_filt, fo+0, reset); \
+		printf("\n"); \
+		exit(f>0); \
+	}'
 
 fmt:
 	cargo fmt --all

--- a/logipack-core/crates/core-application/Cargo.toml
+++ b/logipack-core/crates/core-application/Cargo.toml
@@ -3,6 +3,9 @@ name = "core-application"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+doctest = false
+
 [dependencies]
 uuid = "1.19.0"
 sea-orm = { version = "1", features = ["sqlx-postgres", "runtime-tokio-native-tls"] }

--- a/logipack-core/crates/core-application/src/lib.rs
+++ b/logipack-core/crates/core-application/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod actor;
 pub mod clients;
+pub mod offices;
 pub mod roles;
 pub mod shipments;
 mod validation;

--- a/logipack-core/crates/core-application/src/offices/create.rs
+++ b/logipack-core/crates/core-application/src/offices/create.rs
@@ -1,0 +1,44 @@
+use core_data::repository::offices_repo::{self, OfficeError};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::actor::ActorContext;
+use crate::validation::office::{OfficeValidationError, validate_office};
+
+#[derive(Debug, Clone)]
+pub struct CreateOffice {
+    pub name: String,
+    pub city: String,
+    pub address: String,
+}
+
+#[derive(Debug, Error)]
+pub enum CreateOfficeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("validation error: {0}")]
+    Validation(#[from] OfficeValidationError),
+    #[error("{0}")]
+    OfficeCreationError(#[from] OfficeError),
+}
+
+pub async fn create_office(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    input: CreateOffice,
+) -> Result<Uuid, CreateOfficeError> {
+    // Only admin can create offices
+    if !actor.is_admin() {
+        return Err(CreateOfficeError::Forbidden);
+    }
+
+    validate_office(&input.name, &input.city, &input.address)?;
+
+    let office_id = Uuid::new_v4();
+
+    offices_repo::OfficesRepo::create_office(db, office_id, input.name, input.city, input.address)
+        .await?;
+
+    Ok(office_id)
+}

--- a/logipack-core/crates/core-application/src/offices/delete.rs
+++ b/logipack-core/crates/core-application/src/offices/delete.rs
@@ -1,0 +1,36 @@
+use core_data::repository::offices_repo::{self, OfficeError};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::actor::ActorContext;
+
+#[derive(Debug, Error)]
+pub enum DeleteOfficeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("not found")]
+    NotFound,
+    #[error("{0}")]
+    DeleteOfficeError(#[from] OfficeError),
+}
+
+pub async fn delete_office(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    id: Uuid,
+) -> Result<Uuid, DeleteOfficeError> {
+    // Only admin can delete offices
+    if !actor.is_admin() {
+        return Err(DeleteOfficeError::Forbidden);
+    }
+
+    offices_repo::OfficesRepo::delete_office(db, id)
+        .await
+        .map_err(|e| match e {
+            OfficeError::RecordNotFound => DeleteOfficeError::NotFound,
+            other => DeleteOfficeError::DeleteOfficeError(other),
+        })?;
+
+    Ok(id)
+}

--- a/logipack-core/crates/core-application/src/offices/get.rs
+++ b/logipack-core/crates/core-application/src/offices/get.rs
@@ -1,0 +1,38 @@
+use core_data::{
+    entity::offices,
+    repository::offices_repo::{self, OfficeError},
+};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+
+use crate::actor::ActorContext;
+
+#[derive(Debug, Error)]
+pub enum GetOfficeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("not found")]
+    NotFound,
+    #[error("{0}")]
+    OfficeError(#[from] OfficeError),
+}
+
+pub async fn get_office(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    id: uuid::Uuid,
+) -> Result<Option<offices::Model>, GetOfficeError> {
+    // Only admin can get offices
+    if !actor.is_admin() {
+        return Err(GetOfficeError::Forbidden);
+    }
+
+    let result = offices_repo::OfficesRepo::get_office_by_id(db, id)
+        .await
+        .map_err(|e| match e {
+            OfficeError::RecordNotFound => GetOfficeError::NotFound,
+            other => GetOfficeError::OfficeError(other),
+        })?;
+
+    Ok(result)
+}

--- a/logipack-core/crates/core-application/src/offices/list.rs
+++ b/logipack-core/crates/core-application/src/offices/list.rs
@@ -1,0 +1,30 @@
+use core_data::{
+    entity::offices,
+    repository::offices_repo::{self, OfficeError},
+};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+
+use crate::actor::ActorContext;
+
+#[derive(Debug, Error)]
+pub enum ListOfficesError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("{0}")]
+    OfficeError(#[from] OfficeError),
+}
+
+pub async fn list_offices(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+) -> Result<Vec<offices::Model>, ListOfficesError> {
+    // Only admin can list offices
+    if !actor.is_admin() {
+        return Err(ListOfficesError::Forbidden);
+    }
+
+    let result = offices_repo::OfficesRepo::list_offices(db).await?;
+
+    Ok(result)
+}

--- a/logipack-core/crates/core-application/src/offices/mod.rs
+++ b/logipack-core/crates/core-application/src/offices/mod.rs
@@ -1,0 +1,5 @@
+pub mod create;
+pub mod delete;
+pub mod get;
+pub mod list;
+pub mod update;

--- a/logipack-core/crates/core-application/src/offices/update.rs
+++ b/logipack-core/crates/core-application/src/offices/update.rs
@@ -1,0 +1,61 @@
+use core_data::repository::offices_repo::{self, OfficeError};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::actor::ActorContext;
+use crate::validation::office::{
+    OfficeValidationError, validate_address, validate_city, validate_name,
+};
+
+#[derive(Debug, Clone)]
+pub struct UpdateOffice {
+    pub id: Uuid,
+    pub name: Option<String>,
+    pub city: Option<String>,
+    pub address: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum UpdateOfficeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("validation error: {0}")]
+    Validation(#[from] OfficeValidationError),
+    #[error("not found")]
+    NotFound,
+    #[error("{0}")]
+    UpdateOfficeError(#[from] OfficeError),
+}
+
+pub async fn update_office(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    input: UpdateOffice,
+) -> Result<Uuid, UpdateOfficeError> {
+    // Only admin can update offices
+    if !actor.is_admin() {
+        return Err(UpdateOfficeError::Forbidden);
+    }
+
+    if let Some(ref name) = input.name {
+        validate_name(name)?;
+    }
+
+    if let Some(ref city) = input.city {
+        validate_city(city)?;
+    }
+
+    if let Some(ref address) = input.address {
+        validate_address(address)?;
+    }
+
+    offices_repo::OfficesRepo::update_office(db, input.id, input.name, input.city, input.address)
+        .await
+        .map_err(|e| match e {
+            OfficeError::RecordNotFound => UpdateOfficeError::NotFound,
+            other => UpdateOfficeError::UpdateOfficeError(other),
+        })?;
+
+    Ok(input.id)
+}

--- a/logipack-core/crates/core-application/src/validation/mod.rs
+++ b/logipack-core/crates/core-application/src/validation/mod.rs
@@ -1,1 +1,2 @@
 pub mod client;
+pub mod office;

--- a/logipack-core/crates/core-application/src/validation/office.rs
+++ b/logipack-core/crates/core-application/src/validation/office.rs
@@ -1,0 +1,123 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum OfficeValidationError {
+    #[error("name too short")]
+    NameTooShort,
+    #[error("name too long")]
+    NameTooLong,
+    #[error("city too short")]
+    CityTooShort,
+    #[error("city too long")]
+    CityTooLong,
+    #[error("address too short")]
+    AddressTooShort,
+    #[error("address too long")]
+    AddressTooLong,
+}
+
+pub fn validate_office(name: &str, city: &str, address: &str) -> Result<(), OfficeValidationError> {
+    validate_name(name)?;
+    validate_city(city)?;
+    validate_address(address)?;
+    Ok(())
+}
+
+pub fn validate_name(name: &str) -> Result<(), OfficeValidationError> {
+    let trimmed = name.trim();
+    let len = trimmed.chars().count();
+
+    if len < 2 {
+        return Err(OfficeValidationError::NameTooShort);
+    }
+
+    if len > 100 {
+        return Err(OfficeValidationError::NameTooLong);
+    }
+
+    Ok(())
+}
+
+pub fn validate_city(city: &str) -> Result<(), OfficeValidationError> {
+    let trimmed = city.trim();
+    let len = trimmed.chars().count();
+
+    if len < 2 {
+        return Err(OfficeValidationError::CityTooShort);
+    }
+
+    if len > 100 {
+        return Err(OfficeValidationError::CityTooLong);
+    }
+
+    Ok(())
+}
+
+pub fn validate_address(address: &str) -> Result<(), OfficeValidationError> {
+    let trimmed = address.trim();
+    let len = trimmed.chars().count();
+
+    if len < 2 {
+        return Err(OfficeValidationError::AddressTooShort);
+    }
+
+    if len > 200 {
+        return Err(OfficeValidationError::AddressTooLong);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_office() {
+        let result = validate_office("Main Office", "Sofia", "1 Test Street");
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn empty_name_rejected() {
+        let result = validate_name("   ");
+        assert_eq!(result, Err(OfficeValidationError::NameTooShort));
+    }
+
+    #[test]
+    fn short_name_rejected() {
+        let result = validate_name("A");
+        assert_eq!(result, Err(OfficeValidationError::NameTooShort));
+    }
+
+    #[test]
+    fn long_name_rejected() {
+        let name = "a".repeat(101);
+        let result = validate_name(&name);
+        assert_eq!(result, Err(OfficeValidationError::NameTooLong));
+    }
+
+    #[test]
+    fn empty_city_rejected() {
+        let result = validate_city("   ");
+        assert_eq!(result, Err(OfficeValidationError::CityTooShort));
+    }
+
+    #[test]
+    fn short_city_rejected() {
+        let result = validate_city("A");
+        assert_eq!(result, Err(OfficeValidationError::CityTooShort));
+    }
+
+    #[test]
+    fn empty_address_rejected() {
+        let result = validate_address("   ");
+        assert_eq!(result, Err(OfficeValidationError::AddressTooShort));
+    }
+
+    #[test]
+    fn short_address_rejected() {
+        let result = validate_address("A");
+        assert_eq!(result, Err(OfficeValidationError::AddressTooShort));
+    }
+}

--- a/logipack-core/crates/core-application/tests/offices_usecases.rs
+++ b/logipack-core/crates/core-application/tests/offices_usecases.rs
@@ -1,0 +1,672 @@
+use core_application::actor::ActorContext;
+use core_application::offices::create::{CreateOffice, CreateOfficeError, create_office};
+use core_application::offices::delete::{DeleteOfficeError, delete_office};
+use core_application::offices::get::{GetOfficeError, get_office};
+use core_application::offices::list::ListOfficesError;
+use core_application::offices::update::{UpdateOffice, UpdateOfficeError, update_office};
+use core_application::roles::Role;
+use core_data::entity::{employees, offices, users};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, DatabaseConnection, DbBackend, Set, Statement};
+use test_infra::test_db;
+use uuid::Uuid;
+
+async fn cleanup(db: &DatabaseConnection) {
+    let tables = [
+        "shipment_status_history",
+        "shipments",
+        "employee_offices",
+        "employees",
+        "user_roles",
+        "users",
+        "clients",
+        "roles",
+        "offices",
+        "packages",
+        "streams",
+    ];
+
+    for t in tables {
+        db.execute(Statement::from_string(
+            DbBackend::Postgres,
+            format!("DELETE FROM {}", t),
+        ))
+        .await
+        .unwrap();
+    }
+}
+
+async fn seed_office(db: &DatabaseConnection) -> Uuid {
+    let id = Uuid::new_v4();
+
+    offices::ActiveModel {
+        id: Set(id),
+        name: Set("Main Office".to_string()),
+        city: Set("Sofia".to_string()),
+        address: Set("1 Test Street".to_string()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+async fn seed_user(db: &DatabaseConnection, user_type: Option<String>) -> Uuid {
+    let id = Uuid::new_v4();
+    let email = match user_type {
+        Some(t) => format!("{}+{}@test.com", t, id),
+        None => format!("{}+{}@test.com", "user_any", id),
+    };
+
+    users::ActiveModel {
+        id: Set(id),
+        email: Set(Some(email)),
+        password_hash: Set(Some("x".into())),
+        auth0_sub: Set(None),
+        created_at: Set(chrono::Utc::now().into()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+async fn seed_employee(db: &DatabaseConnection, user_id: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+
+    employees::ActiveModel {
+        id: Set(id),
+        user_id: Set(user_id),
+        full_name: Set("Test Employee".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+async fn admin_actor(db: &DatabaseConnection) -> ActorContext {
+    let user_id = seed_user(db, Some("admin".to_string())).await;
+
+    ActorContext {
+        user_id,
+        sub: "admin".into(),
+        roles: vec![Role::Admin],
+        employee_id: None,
+        allowed_office_ids: vec![],
+    }
+}
+
+async fn employee_actor(db: &DatabaseConnection) -> ActorContext {
+    let user_id = seed_user(db, Some("employee".to_string())).await;
+    let employee_id = seed_employee(db, user_id).await;
+
+    ActorContext {
+        user_id,
+        sub: "employee".into(),
+        roles: vec![Role::Employee],
+        employee_id: Some(employee_id),
+        allowed_office_ids: vec![],
+    }
+}
+
+async fn no_role_actor(db: &DatabaseConnection) -> ActorContext {
+    let user_id = seed_user(db, None).await;
+
+    ActorContext {
+        user_id,
+        sub: "".into(),
+        roles: vec![],
+        employee_id: None,
+        allowed_office_ids: vec![],
+    }
+}
+
+/* -------------------- */
+/* Create Office tests */
+/* -------------------- */
+
+#[tokio::test]
+async fn admin_can_create_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let office_id = create_office(
+        &db,
+        &admin,
+        CreateOffice {
+            name: "Main Office".to_string(),
+            city: "Sofia".to_string(),
+            address: "1 Test Street".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = get_office(&db, &admin, office_id).await.unwrap();
+    assert!(result.is_some());
+
+    let result = result.unwrap();
+    assert_eq!(result.name, "Main Office".to_string());
+    assert_eq!(result.city, "Sofia".to_string());
+    assert_eq!(result.address, "1 Test Street".to_string());
+}
+
+#[tokio::test]
+async fn employee_cannot_create_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+
+    let result = create_office(
+        &db,
+        &employee,
+        CreateOffice {
+            name: "Main Office".to_string(),
+            city: "Sofia".to_string(),
+            address: "1 Test Street".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, CreateOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_create_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+
+    let result = create_office(
+        &db,
+        &user,
+        CreateOffice {
+            name: "Main Office".to_string(),
+            city: "Sofia".to_string(),
+            address: "1 Test Street".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, CreateOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn invalid_office_data_cannot_create_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let invalid_name = create_office(
+        &db,
+        &admin,
+        CreateOffice {
+            name: "".to_string(),
+            city: "Sofia".to_string(),
+            address: "1 Test Street".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(invalid_name, CreateOfficeError::Validation(_)));
+
+    let invalid_city = create_office(
+        &db,
+        &admin,
+        CreateOffice {
+            name: "Main Office".to_string(),
+            city: "".to_string(),
+            address: "1 Test Street".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(invalid_city, CreateOfficeError::Validation(_)));
+
+    let invalid_address = create_office(
+        &db,
+        &admin,
+        CreateOffice {
+            name: "Main Office".to_string(),
+            city: "Sofia".to_string(),
+            address: "".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(invalid_address, CreateOfficeError::Validation(_)));
+}
+
+/* -------------------- */
+/* Update Offices tests */
+/* -------------------- */
+
+#[tokio::test]
+async fn admin_can_update_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let updated_id = update_office(
+        &db,
+        &admin,
+        UpdateOffice {
+            id: office_id,
+            name: Some("Updated Office".to_string()),
+            city: None,
+            address: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = get_office(&db, &admin, updated_id).await.unwrap();
+    assert!(result.is_some());
+
+    let result = result.unwrap();
+    assert_eq!(result.name, "Updated Office".to_string());
+    assert_eq!(result.city, "Sofia".to_string());
+    assert_eq!(result.address, "1 Test Street".to_string());
+}
+
+#[tokio::test]
+async fn employee_cannot_update_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let result = update_office(
+        &db,
+        &employee,
+        UpdateOffice {
+            id: office_id,
+            name: Some("Updated Office".to_string()),
+            city: None,
+            address: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, UpdateOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_update_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let result = update_office(
+        &db,
+        &user,
+        UpdateOffice {
+            id: office_id,
+            name: Some("Updated Office".to_string()),
+            city: None,
+            address: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, UpdateOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn invalid_office_data_cannot_update_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let office_id = seed_office(&db).await;
+
+    let invalid_name = update_office(
+        &db,
+        &admin,
+        UpdateOffice {
+            id: office_id,
+            name: Some("".to_string()),
+            city: None,
+            address: None,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(invalid_name, UpdateOfficeError::Validation(_)));
+
+    let invalid_city = update_office(
+        &db,
+        &admin,
+        UpdateOffice {
+            id: office_id,
+            name: None,
+            city: Some("".to_string()),
+            address: None,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(invalid_city, UpdateOfficeError::Validation(_)));
+
+    let invalid_address = update_office(
+        &db,
+        &admin,
+        UpdateOffice {
+            id: office_id,
+            name: None,
+            city: None,
+            address: Some("".to_string()),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(invalid_address, UpdateOfficeError::Validation(_)));
+}
+
+#[tokio::test]
+async fn updating_nonexistent_office_returns_error() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let result = update_office(
+        &db,
+        &admin,
+        UpdateOffice {
+            id: Uuid::new_v4(),
+            name: Some("Updated Office".to_string()),
+            city: None,
+            address: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, UpdateOfficeError::NotFound));
+}
+
+#[tokio::test]
+async fn updating_deleted_office_returns_error() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    delete_office(&db, &admin, office_id).await.unwrap();
+
+    let result = update_office(
+        &db,
+        &admin,
+        UpdateOffice {
+            id: office_id,
+            name: None,
+            city: None,
+            address: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, UpdateOfficeError::NotFound));
+}
+
+/* -------------------- */
+/* Delete Office tests */
+/* -------------------- */
+
+#[tokio::test]
+async fn admin_can_delete_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    delete_office(&db, &admin, office_id).await.unwrap();
+
+    let result = get_office(&db, &admin, office_id).await.unwrap_err();
+    assert!(matches!(result, GetOfficeError::NotFound));
+}
+
+#[tokio::test]
+async fn employee_cannot_delete_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let result = delete_office(&db, &employee, office_id).await.unwrap_err();
+
+    assert!(matches!(result, DeleteOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_delete_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let result = delete_office(&db, &user, office_id).await.unwrap_err();
+
+    assert!(matches!(result, DeleteOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn deleting_nonexistent_office_returns_error() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let result = delete_office(&db, &admin, Uuid::new_v4())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, DeleteOfficeError::NotFound));
+}
+
+#[tokio::test]
+async fn deleting_already_deleted_office_returns_error() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    delete_office(&db, &admin, office_id).await.unwrap();
+
+    let result = delete_office(&db, &admin, office_id).await.unwrap_err();
+
+    assert!(matches!(result, DeleteOfficeError::NotFound));
+}
+
+/* ---------------- */
+/* Get Office tests */
+/* ---------------- */
+
+#[tokio::test]
+async fn admin_can_get_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let result = get_office(&db, &admin, office_id).await.unwrap();
+    assert!(result.is_some());
+
+    let result = result.unwrap();
+    assert_eq!(result.name, "Main Office".to_string());
+    assert_eq!(result.city, "Sofia".to_string());
+    assert_eq!(result.address, "1 Test Street".to_string());
+}
+
+#[tokio::test]
+async fn employee_cannot_get_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let result = get_office(&db, &employee, office_id).await.unwrap_err();
+
+    assert!(matches!(result, GetOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_get_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let result = get_office(&db, &user, office_id).await.unwrap_err();
+
+    assert!(matches!(result, GetOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn getting_nonexistent_office_returns_none() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let result = get_office(&db, &admin, Uuid::new_v4()).await.unwrap_err();
+
+    assert!(matches!(result, GetOfficeError::NotFound));
+}
+
+/* ----------------- */
+/* List Offices test */
+/* ----------------- */
+
+#[tokio::test]
+async fn admin_can_list_offices() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    // Seed multiple offices
+    for i in 0..5 {
+        create_office(
+            &db,
+            &admin,
+            CreateOffice {
+                name: format!("Office {}", i),
+                city: "Sofia".to_string(),
+                address: format!("{} Test Street", i),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let result = core_application::offices::list::list_offices(&db, &admin)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 5);
+}
+
+#[tokio::test]
+async fn employee_cannot_list_offices() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+    let admin = admin_actor(&db).await;
+
+    // Seed multiple offices
+    for i in 0..5 {
+        create_office(
+            &db,
+            &admin,
+            CreateOffice {
+                name: format!("Office {}", i),
+                city: "Sofia".to_string(),
+                address: format!("{} Test Street", i),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let result = core_application::offices::list::list_offices(&db, &employee)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, ListOfficesError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_list_offices() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+    let admin = admin_actor(&db).await;
+
+    // Seed multiple offices
+    for i in 0..5 {
+        create_office(
+            &db,
+            &admin,
+            CreateOffice {
+                name: format!("Office {}", i),
+                city: "Sofia".to_string(),
+                address: format!("{} Test Street", i),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let result = core_application::offices::list::list_offices(&db, &user)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, ListOfficesError::Forbidden));
+}

--- a/logipack-core/crates/core-application/tests/shipments_usecases.rs
+++ b/logipack-core/crates/core-application/tests/shipments_usecases.rs
@@ -45,6 +45,9 @@ async fn seed_client(db: &DatabaseConnection) -> Uuid {
         name: Set("Test Client".into()),
         phone: Set(None),
         email: Set(None),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
     }
     .insert(db)
     .await
@@ -61,6 +64,9 @@ async fn seed_office(db: &DatabaseConnection) -> Uuid {
         name: Set("Office".into()),
         city: Set("City".into()),
         address: Set("Address".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
     }
     .insert(db)
     .await
@@ -97,6 +103,9 @@ async fn seed_employee(db: &DatabaseConnection, user_id: Uuid) -> Uuid {
         id: Set(id),
         user_id: Set(user_id),
         full_name: Set("Test Employee".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
     }
     .insert(db)
     .await

--- a/logipack-core/crates/core-contracts/Cargo.toml
+++ b/logipack-core/crates/core-contracts/Cargo.toml
@@ -3,4 +3,7 @@ name = "core-contracts"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+doctest = false
+
 [dependencies]

--- a/logipack-core/crates/core-data/Cargo.toml
+++ b/logipack-core/crates/core-data/Cargo.toml
@@ -3,6 +3,9 @@ name = "core-data"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+doctest = false
+
 [dependencies]
 sea-orm = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }
 uuid = { version = "1", features = ["v4"] }

--- a/logipack-core/crates/core-data/migration/Cargo.toml
+++ b/logipack-core/crates/core-data/migration/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [lib]
 name = "core_data_migration"
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 sea-orm-migration = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }

--- a/logipack-core/crates/core-data/migration/src/lib.rs
+++ b/logipack-core/crates/core-data/migration/src/lib.rs
@@ -4,6 +4,7 @@ mod m2026_01_13_init;
 mod m2026_01_26_add_auth0_sub_to_users;
 mod m2026_01_27_email_nullable;
 mod m2026_01_27_password_hash_nullable;
+mod m2026_02_13_soft_delete;
 
 pub struct Migrator;
 
@@ -15,6 +16,7 @@ impl MigratorTrait for Migrator {
             Box::new(m2026_01_26_add_auth0_sub_to_users::Migration),
             Box::new(m2026_01_27_password_hash_nullable::Migration),
             Box::new(m2026_01_27_email_nullable::Migration),
+            Box::new(m2026_02_13_soft_delete::Migration),
         ]
     }
 

--- a/logipack-core/crates/core-data/migration/src/m2026_02_13_soft_delete.rs
+++ b/logipack-core/crates/core-data/migration/src/m2026_02_13_soft_delete.rs
@@ -1,0 +1,149 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add a deleted_at column to clients for soft deletes
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE clients
+                ADD COLUMN deleted_at TIMESTAMPTZ;
+                "#,
+            )
+            .await?;
+
+        // Add a deleted_at column to offices for soft deletes
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE offices 
+                ADD COLUMN deleted_at TIMESTAMPTZ;
+                "#,
+            )
+            .await?;
+
+        // Add a deleted_at column to employees for soft deletes
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE employees 
+                ADD COLUMN deleted_at TIMESTAMPTZ;
+                "#,
+            )
+            .await?;
+
+        // Add created_at and updated_at columns to clients, employees, offices
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE clients
+                ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+                "#,
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE offices
+                ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+                "#,
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE employees
+                ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Remove the deleted_at column from clients
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE clients
+                DROP COLUMN deleted_at;
+                "#,
+            )
+            .await?;
+
+        // Remove the deleted_at column from offices
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE offices
+                DROP COLUMN deleted_at;
+                "#,
+            )
+            .await?;
+
+        // Remove the deleted_at column from employees
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE employees
+                DROP COLUMN deleted_at;
+                "#,
+            )
+            .await?;
+
+        // Remove created_at and updated_at columns from clients, employees, offices
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE clients
+                DROP COLUMN created_at,
+                DROP COLUMN updated_at;
+                "#,
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE offices
+                DROP COLUMN created_at,
+                DROP COLUMN updated_at;
+                "#,
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE employees
+                DROP COLUMN created_at,
+                DROP COLUMN updated_at;
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/logipack-core/crates/core-data/src/entity/clients.rs
+++ b/logipack-core/crates/core-data/src/entity/clients.rs
@@ -9,6 +9,9 @@ pub struct Model {
     pub name: String,
     pub phone: Option<String>,
     pub email: Option<String>,
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+    pub deleted_at: Option<DateTimeWithTimeZone>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter)]

--- a/logipack-core/crates/core-data/src/entity/employees.rs
+++ b/logipack-core/crates/core-data/src/entity/employees.rs
@@ -9,6 +9,10 @@ pub struct Model {
     pub user_id: Uuid,
 
     pub full_name: String,
+
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+    pub deleted_at: Option<DateTimeWithTimeZone>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter)]

--- a/logipack-core/crates/core-data/src/entity/offices.rs
+++ b/logipack-core/crates/core-data/src/entity/offices.rs
@@ -9,6 +9,10 @@ pub struct Model {
     pub name: String,
     pub city: String,
     pub address: String,
+
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+    pub deleted_at: Option<DateTimeWithTimeZone>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter)]

--- a/logipack-core/crates/core-data/src/repository/mod.rs
+++ b/logipack-core/crates/core-data/src/repository/mod.rs
@@ -1,2 +1,3 @@
 pub mod clients_repo;
+pub mod offices_repo;
 pub mod shipments_repo;

--- a/logipack-core/crates/core-data/src/repository/offices_repo.rs
+++ b/logipack-core/crates/core-data/src/repository/offices_repo.rs
@@ -1,0 +1,121 @@
+use sea_orm::ActiveValue::Set;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, DbErr, EntityTrait, IntoActiveModel,
+    QueryFilter,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::entity::offices;
+
+#[derive(Debug, Error)]
+pub enum OfficeError {
+    #[error("db error: {0}")]
+    OfficeDbError(#[from] DbErr),
+    #[error("office not found")]
+    RecordNotFound,
+}
+
+pub struct OfficesRepo;
+
+impl OfficesRepo {
+    /// Creates a new office
+    pub async fn create_office(
+        db: &DatabaseConnection,
+        id: Uuid,
+        name: String,
+        city: String,
+        address: String,
+    ) -> Result<(), OfficeError> {
+        let model = offices::ActiveModel {
+            id: Set(id),
+            name: Set(name),
+            city: Set(city),
+            address: Set(address),
+            created_at: Set(chrono::Utc::now().into()),
+            updated_at: Set(chrono::Utc::now().into()),
+            deleted_at: Set(None),
+        };
+
+        model.insert(db).await?;
+        Ok(())
+    }
+
+    /// Gets office by id
+    pub async fn get_office_by_id(
+        db: &DatabaseConnection,
+        id: Uuid,
+    ) -> Result<Option<offices::Model>, OfficeError> {
+        let retrieved = offices::Entity::find_by_id(id).one(db).await?;
+
+        // If the office is not found or is soft-deleted, return RecordNotFound error
+        if retrieved.is_none() || retrieved.as_ref().unwrap().deleted_at.is_some() {
+            return Err(OfficeError::RecordNotFound);
+        }
+
+        Ok(retrieved)
+    }
+
+    /// Lists all offices
+    pub async fn list_offices(db: &DatabaseConnection) -> Result<Vec<offices::Model>, OfficeError> {
+        // Only return offices that are not soft-deleted
+        let retrieved = offices::Entity::find()
+            .filter(offices::Column::DeletedAt.is_null())
+            .all(db)
+            .await?;
+        Ok(retrieved)
+    }
+
+    /// Updates an office's information
+    pub async fn update_office(
+        db: &DatabaseConnection,
+        id: Uuid,
+        name: Option<String>,
+        city: Option<String>,
+        address: Option<String>,
+    ) -> Result<(), OfficeError> {
+        // Exlude soft-deleted records from the search
+        let mut model = offices::Entity::find_by_id(id)
+            .filter(offices::Column::DeletedAt.is_null())
+            .one(db)
+            .await?
+            .ok_or(OfficeError::RecordNotFound)?
+            .into_active_model();
+
+        if let Some(name) = name {
+            model.name = Set(name);
+        }
+
+        if let Some(city) = city {
+            model.city = Set(city);
+        }
+
+        if let Some(address) = address {
+            model.address = Set(address);
+        }
+
+        model.updated_at = Set(chrono::Utc::now().into());
+
+        model.update(db).await?;
+        Ok(())
+    }
+
+    /// Soft deletes an office by id
+    pub async fn delete_office(db: &DatabaseConnection, id: Uuid) -> Result<(), OfficeError> {
+        let result = offices::Entity::update_many()
+            .col_expr(
+                offices::Column::DeletedAt,
+                sea_orm::sea_query::Expr::cust("NOW()"),
+            )
+            .filter(offices::Column::Id.eq(id))
+            .filter(offices::Column::DeletedAt.is_null())
+            .exec(db)
+            .await?;
+
+        if result.rows_affected == 0 {
+            return Err(OfficeError::RecordNotFound);
+        }
+
+        Ok(())
+    }
+}

--- a/logipack-core/crates/core-data/tests/shipments_repo.rs
+++ b/logipack-core/crates/core-data/tests/shipments_repo.rs
@@ -17,6 +17,9 @@ pub async fn seed_client(db: &DatabaseConnection) -> Uuid {
         name: Set("Test Client".into()),
         phone: Set(None),
         email: Set(None),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
     }
     .insert(db)
     .await

--- a/logipack-core/crates/core-domain/Cargo.toml
+++ b/logipack-core/crates/core-domain/Cargo.toml
@@ -3,6 +3,9 @@ name = "core-domain"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = "1.0.228"
 thiserror = "2"

--- a/logipack-core/crates/core-eventstore/Cargo.toml
+++ b/logipack-core/crates/core-eventstore/Cargo.toml
@@ -3,6 +3,9 @@ name = "core-eventstore"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+doctest = false
+
 [dependencies]
 sea-orm = { version = "1", features = ["macros", "with-uuid", "with-chrono"] }
 uuid = { version = "1", features = ["v4"] }

--- a/logipack-core/crates/core-eventstore/migration/Cargo.toml
+++ b/logipack-core/crates/core-eventstore/migration/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 publish = false
 
 [lib]
+doctest = false
 name = "core_eventstore_migration"
 path = "src/lib.rs"
 

--- a/logipack-core/crates/test-infra/Cargo.toml
+++ b/logipack-core/crates/test-infra/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[lib]
+doctest = false
+
 [dependencies]
 sea-orm = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }
 sea-orm-migration = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }

--- a/logipack-hub/hub-api/Cargo.toml
+++ b/logipack-hub/hub-api/Cargo.toml
@@ -3,6 +3,9 @@ name = "hub-api"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+doctest = false
+
 [dependencies]
 axum = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/logipack-hub/hub-api/src/dto/mod.rs
+++ b/logipack-hub/hub-api/src/dto/mod.rs
@@ -1,2 +1,3 @@
 pub mod clients;
+pub mod offices;
 pub mod shipments;

--- a/logipack-hub/hub-api/src/dto/offices.rs
+++ b/logipack-hub/hub-api/src/dto/offices.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OfficeDto {
+    pub id: String,
+    pub name: String,
+    pub city: String,
+    pub address: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateOfficeRequest {
+    pub name: String,
+    pub city: String,
+    pub address: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateOfficeResponse {
+    pub office_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListOfficesResponse {
+    pub offices: Vec<OfficeDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetOfficeResponse {
+    pub office: OfficeDto,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateOfficeRequest {
+    pub name: Option<String>,
+    pub city: Option<String>,
+    pub address: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateOfficeResponse {
+    pub office_id: String,
+}

--- a/logipack-hub/hub-api/src/routes/admin.rs
+++ b/logipack-hub/hub-api/src/routes/admin.rs
@@ -1,6 +1,11 @@
-use crate::{routes::admin_ep::clients, state::AppState};
+use crate::{
+    routes::admin_ep::{clients, offices},
+    state::AppState,
+};
 use axum::Router;
 
 pub fn router() -> Router<AppState> {
-    Router::new().nest("/clients", clients::router())
+    Router::new()
+        .nest("/clients", clients::router())
+        .nest("/offices", offices::router())
 }

--- a/logipack-hub/hub-api/src/routes/admin_ep/mod.rs
+++ b/logipack-hub/hub-api/src/routes/admin_ep/mod.rs
@@ -1,1 +1,2 @@
 pub mod clients;
+pub mod offices;

--- a/logipack-hub/hub-api/src/routes/admin_ep/offices.rs
+++ b/logipack-hub/hub-api/src/routes/admin_ep/offices.rs
@@ -1,0 +1,208 @@
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    routing::{delete, get, post, put},
+};
+use core_application::actor::ActorContext;
+
+use crate::{
+    dto::offices::{
+        CreateOfficeRequest, CreateOfficeResponse, GetOfficeResponse, ListOfficesResponse,
+        OfficeDto, UpdateOfficeRequest, UpdateOfficeResponse,
+    },
+    error::ApiError,
+    policy,
+    state::AppState,
+};
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_offices_handler))
+        .route("/:id", get(get_office_handler))
+        .route("/", post(create_office_handler))
+        .route("/:id", put(update_office_handler))
+        .route("/:id", delete(delete_office_handler))
+}
+
+async fn list_offices_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+) -> Result<Json<ListOfficesResponse>, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let out = core_application::offices::list::list_offices(&state.db, &actor)
+        .await
+        .map_err(|e| match e {
+            core_application::offices::list::ListOfficesError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::offices::list::ListOfficesError::OfficeError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    let dtos: Vec<OfficeDto> = out
+        .into_iter()
+        .map(|office| OfficeDto {
+            id: office.id.to_string(),
+            name: office.name,
+            city: office.city,
+            address: office.address,
+        })
+        .collect();
+
+    let result = ListOfficesResponse { offices: dtos };
+
+    Ok(Json(result))
+}
+
+async fn get_office_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Path(id): Path<String>,
+) -> Result<Json<GetOfficeResponse>, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    // check if office_id is a valid UUID
+    let office_uuid = id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_office_id", "Office ID must be a valid UUID")
+    })?;
+
+    let out = core_application::offices::get::get_office(&state.db, &actor, office_uuid)
+        .await
+        .map_err(|e| match e {
+            core_application::offices::get::GetOfficeError::NotFound => {
+                ApiError::not_found("office_not_found", "Office not found")
+            }
+            core_application::offices::get::GetOfficeError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::offices::get::GetOfficeError::OfficeError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    let office = out.ok_or_else(|| ApiError::not_found("office_not_found", "Office not found"))?;
+    let result = GetOfficeResponse {
+        office: OfficeDto {
+            id: office.id.to_string(),
+            name: office.name,
+            city: office.city,
+            address: office.address,
+        },
+    };
+
+    Ok(Json(result))
+}
+
+async fn create_office_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Json(request): Json<CreateOfficeRequest>,
+) -> Result<(axum::http::StatusCode, Json<CreateOfficeResponse>), ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let input = core_application::offices::create::CreateOffice {
+        name: request.name,
+        city: request.city,
+        address: request.address,
+    };
+
+    let office_id = core_application::offices::create::create_office(&state.db, &actor, input)
+        .await
+        .map_err(|e| match e {
+            core_application::offices::create::CreateOfficeError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::offices::create::CreateOfficeError::Validation(err) => {
+                ApiError::bad_request("invalid_office", err.to_string())
+            }
+            core_application::offices::create::CreateOfficeError::OfficeCreationError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    let result = CreateOfficeResponse {
+        office_id: office_id.to_string(),
+    };
+
+    Ok((axum::http::StatusCode::CREATED, Json(result)))
+}
+
+async fn update_office_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Path(id): Path<String>,
+    Json(request): Json<UpdateOfficeRequest>,
+) -> Result<Json<UpdateOfficeResponse>, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    // check if office_id is a valid UUID
+    let office_uuid = id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_office_id", "Office ID must be a valid UUID")
+    })?;
+
+    let input = core_application::offices::update::UpdateOffice {
+        id: office_uuid,
+        name: request.name,
+        city: request.city,
+        address: request.address,
+    };
+
+    let out = core_application::offices::update::update_office(&state.db, &actor, input)
+        .await
+        .map_err(|e| match e {
+            core_application::offices::update::UpdateOfficeError::NotFound => {
+                ApiError::not_found("office_not_found", "Office not found")
+            }
+            core_application::offices::update::UpdateOfficeError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::offices::update::UpdateOfficeError::Validation(err) => {
+                ApiError::bad_request("invalid_office", err.to_string())
+            }
+            core_application::offices::update::UpdateOfficeError::UpdateOfficeError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    let result = UpdateOfficeResponse {
+        office_id: out.to_string(),
+    };
+
+    Ok(Json(result))
+}
+
+async fn delete_office_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Path(id): Path<String>,
+) -> Result<axum::http::StatusCode, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    // check if office_id is a valid UUID
+    let office_uuid = id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_office_id", "Office ID must be a valid UUID")
+    })?;
+
+    core_application::offices::delete::delete_office(&state.db, &actor, office_uuid)
+        .await
+        .map_err(|e| match e {
+            core_application::offices::delete::DeleteOfficeError::NotFound => {
+                ApiError::not_found("office_not_found", "Office not found")
+            }
+            core_application::offices::delete::DeleteOfficeError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::offices::delete::DeleteOfficeError::DeleteOfficeError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}

--- a/logipack-hub/hub-api/tests/helpers.rs
+++ b/logipack-hub/hub-api/tests/helpers.rs
@@ -441,6 +441,9 @@ pub async fn seed_client(db: &DatabaseConnection) -> Uuid {
         name: Set("Test Client".into()),
         phone: Set(None),
         email: Set(None),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
     }
     .insert(db)
     .await
@@ -461,6 +464,9 @@ pub async fn seed_office(db: &DatabaseConnection) -> Uuid {
         name: Set("Main Office".into()),
         city: Set("Test City".into()),
         address: Set("Test Address".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
     }
     .insert(db)
     .await

--- a/logipack-hub/hub-api/tests/offices.rs
+++ b/logipack-hub/hub-api/tests/offices.rs
@@ -1,0 +1,17 @@
+#[path = "helpers.rs"]
+pub mod helpers;
+
+#[path = "offices/offices_create.rs"]
+mod offices_create;
+
+#[path = "offices/offices_get.rs"]
+mod offices_get;
+
+#[path = "offices/offices_list.rs"]
+mod offices_list;
+
+#[path = "offices/offices_update.rs"]
+mod offices_update;
+
+#[path = "offices/offices_delete.rs"]
+mod offices_delete;

--- a/logipack-hub/hub-api/tests/offices/offices_create.rs
+++ b/logipack-hub/hub-api/tests/offices/offices_create.rs
@@ -1,0 +1,124 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+};
+use http_body_util::BodyExt;
+use hub_api::dto::offices::CreateOfficeResponse;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::helpers::{seed_employee, setup_app_with_admin, setup_app_with_db};
+
+#[tokio::test]
+async fn admin_can_create_office() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri("/admin/offices")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "name": "Main Office",
+                        "city": "Test City",
+                        "address": "123 Test Street",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::CREATED);
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: CreateOfficeResponse = serde_json::from_slice(&body).unwrap();
+    let office_id = Uuid::parse_str(&body.office_id).unwrap();
+
+    assert_ne!(office_id, Uuid::nil());
+}
+
+#[tokio::test]
+async fn employee_cannot_create_office() {
+    let (app, db) = setup_app_with_db().await;
+
+    let employee = seed_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri("/admin/offices")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "name": "Main Office",
+                        "city": "Test City",
+                        "address": "123 Test Street",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_create_office() {
+    let (app, _db) = setup_app_with_db().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri("/admin/offices")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "name": "Main Office",
+                        "city": "Test City",
+                        "address": "123 Test Street",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn create_office_invalid_json() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri("/admin/offices")
+                .body(Body::from("{invalid"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}

--- a/logipack-hub/hub-api/tests/offices/offices_delete.rs
+++ b/logipack-hub/hub-api/tests/offices/offices_delete.rs
@@ -1,0 +1,111 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::helpers::{seed_employee, seed_office, setup_app_with_admin, setup_app_with_db};
+
+#[tokio::test]
+async fn admin_can_delete_office() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!("/admin/offices/{}", office_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn admin_delete_office_invalid_uuid() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri("/admin/offices/not-a-uuid")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn admin_delete_office_not_found() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!("/admin/offices/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn employee_cannot_delete_office() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!("/admin/offices/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_delete_office() {
+    let (app, _db) = setup_app_with_db().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .method(Method::DELETE)
+                .uri(format!("/admin/offices/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/logipack-hub/hub-api/tests/offices/offices_get.rs
+++ b/logipack-hub/hub-api/tests/offices/offices_get.rs
@@ -1,0 +1,110 @@
+use axum::{body::Body, extract::Request, http::StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use hub_api::dto::offices::GetOfficeResponse;
+
+use crate::helpers::{seed_employee, seed_office, setup_app_with_admin, setup_app_with_db};
+
+#[tokio::test]
+async fn admin_can_get_office() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri(format!("/admin/offices/{}", office_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: GetOfficeResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(body.office.id, office_id.to_string());
+}
+
+#[tokio::test]
+async fn admin_get_office_invalid_uuid() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri("/admin/offices/not-a-uuid")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn admin_get_office_not_found() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri(format!("/admin/offices/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn employee_cannot_get_office() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .uri(format!("/admin/offices/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_get_office() {
+    let (app, _db) = setup_app_with_db().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .uri(format!("/admin/offices/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/logipack-hub/hub-api/tests/offices/offices_list.rs
+++ b/logipack-hub/hub-api/tests/offices/offices_list.rs
@@ -1,0 +1,98 @@
+use axum::{body::Body, extract::Request, http::StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use hub_api::dto::offices::ListOfficesResponse;
+
+use crate::helpers::{seed_employee, seed_office, setup_app_with_admin, setup_app_with_db};
+
+#[tokio::test]
+async fn list_offices_empty() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri("/admin/offices")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: ListOfficesResponse = serde_json::from_slice(&body).unwrap();
+
+    assert!(body.offices.is_empty());
+}
+
+#[tokio::test]
+async fn list_offices_returns_rows() {
+    let (app, db, admin) = setup_app_with_admin().await;
+
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri("/admin/offices")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: ListOfficesResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(body.offices.len(), 1);
+    assert_eq!(body.offices[0].id, office_id.to_string());
+}
+
+#[tokio::test]
+async fn employee_cannot_list_offices() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .uri("/admin/offices")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_list_offices() {
+    let (app, _db) = setup_app_with_db().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .uri("/admin/offices")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/logipack-hub/hub-api/tests/offices/offices_update.rs
+++ b/logipack-hub/hub-api/tests/offices/offices_update.rs
@@ -1,0 +1,175 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use hub_api::dto::offices::UpdateOfficeResponse;
+
+use crate::helpers::{seed_employee, seed_office, setup_app_with_admin, setup_app_with_db};
+
+#[tokio::test]
+async fn admin_can_update_office() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/offices/{}", office_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "name": "Updated Office",
+                        "city": "Updated City",
+                        "address": "Updated Address"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: UpdateOfficeResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(body.office_id, office_id.to_string());
+}
+
+#[tokio::test]
+async fn admin_update_office_invalid_uuid() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri("/admin/offices/not-a-uuid")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "name": "Updated Office"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn admin_update_office_not_found() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/offices/{}", Uuid::new_v4()))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "name": "Updated Office"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn admin_update_office_invalid_json() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/offices/{}", Uuid::new_v4()))
+                .body(Body::from("{invalid"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn employee_cannot_update_office() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/offices/{}", office_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "name": "Updated Office"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_update_office() {
+    let (app, db) = setup_app_with_db().await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/offices/{}", office_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "name": "Updated Office"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
…ests)

- Add core-application offices module (create/get/list/update/delete) with validation and RBAC
- Add core-data OfficesRepo with soft-delete aware queries
- Add hub-api admin /offices routes + DTOs
- Add unit + integration tests covering admin vs employee/no-role, invalid UUID, not-found, invalid JSON

Closes #7 
Closes #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Office management: create, read, update, delete, and list offices via new admin-only API endpoints

* **Infrastructure**
  * Soft-delete support and audit timestamps (created_at, updated_at, deleted_at) with a database migration to track them

* **Tests**
  * Comprehensive integration tests covering office CRUD, authorization rules (admin-only), validation, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->