### PR TITLE
feat(admin): implement employee CRUD (core, repo, API) with soft-delete + tests

### DIFF
--- a/logipack-core/crates/core-application/src/employees/create.rs
+++ b/logipack-core/crates/core-application/src/employees/create.rs
@@ -1,0 +1,43 @@
+use core_data::repository::employees_repo::{self, EmployeeError};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::actor::ActorContext;
+use crate::validation::employee::{EmployeeValidationError, validate_full_name};
+
+#[derive(Debug, Clone)]
+pub struct CreateEmployee {
+    pub user_id: Uuid,
+    pub full_name: String,
+}
+
+#[derive(Debug, Error)]
+pub enum CreateEmployeeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("validation error: {0}")]
+    Validation(#[from] EmployeeValidationError),
+    #[error("{0}")]
+    EmployeeCreationError(#[from] EmployeeError),
+}
+
+pub async fn create_employee(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    input: CreateEmployee,
+) -> Result<Uuid, CreateEmployeeError> {
+    // Only admin can create employees
+    if !actor.is_admin() {
+        return Err(CreateEmployeeError::Forbidden);
+    }
+
+    validate_full_name(&input.full_name)?;
+
+    let employee_id = Uuid::new_v4();
+
+    employees_repo::EmployeesRepo::create_employee(db, employee_id, input.user_id, input.full_name)
+        .await?;
+
+    Ok(employee_id)
+}

--- a/logipack-core/crates/core-application/src/employees/delete.rs
+++ b/logipack-core/crates/core-application/src/employees/delete.rs
@@ -1,0 +1,36 @@
+use core_data::repository::employees_repo::{self, EmployeeError};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::actor::ActorContext;
+
+#[derive(Debug, Error)]
+pub enum DeleteEmployeeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("not found")]
+    NotFound,
+    #[error("{0}")]
+    EmployeeError(EmployeeError),
+}
+
+pub async fn delete_employee(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    id: Uuid,
+) -> Result<Uuid, DeleteEmployeeError> {
+    // Only admin can delete employees
+    if !actor.is_admin() {
+        return Err(DeleteEmployeeError::Forbidden);
+    }
+
+    employees_repo::EmployeesRepo::delete_employee(db, id)
+        .await
+        .map_err(|e| match e {
+            EmployeeError::RecordNotFound => DeleteEmployeeError::NotFound,
+            other => DeleteEmployeeError::EmployeeError(other),
+        })?;
+
+    Ok(id)
+}

--- a/logipack-core/crates/core-application/src/employees/get.rs
+++ b/logipack-core/crates/core-application/src/employees/get.rs
@@ -1,0 +1,38 @@
+use core_data::{
+    entity::employees,
+    repository::employees_repo::{self, EmployeeError},
+};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+
+use crate::actor::ActorContext;
+
+#[derive(Debug, Error)]
+pub enum GetEmployeeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("not found")]
+    NotFound,
+    #[error("{0}")]
+    EmployeeError(#[from] EmployeeError),
+}
+
+pub async fn get_employee(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    id: uuid::Uuid,
+) -> Result<Option<employees::Model>, GetEmployeeError> {
+    // Only admin can get employees
+    if !actor.is_admin() {
+        return Err(GetEmployeeError::Forbidden);
+    }
+
+    let result = employees_repo::EmployeesRepo::get_employee_by_id(db, id)
+        .await
+        .map_err(|e| match e {
+            EmployeeError::RecordNotFound => GetEmployeeError::NotFound,
+            other => GetEmployeeError::EmployeeError(other),
+        })?;
+
+    Ok(result)
+}

--- a/logipack-core/crates/core-application/src/employees/list.rs
+++ b/logipack-core/crates/core-application/src/employees/list.rs
@@ -1,0 +1,30 @@
+use core_data::{
+    entity::employees,
+    repository::employees_repo::{self, EmployeeError},
+};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+
+use crate::actor::ActorContext;
+
+#[derive(Debug, Error)]
+pub enum ListEmployeesError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("{0}")]
+    EmployeeError(#[from] EmployeeError),
+}
+
+pub async fn list_employees(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+) -> Result<Vec<employees::Model>, ListEmployeesError> {
+    // Only admin can list employees
+    if !actor.is_admin() {
+        return Err(ListEmployeesError::Forbidden);
+    }
+
+    let result = employees_repo::EmployeesRepo::list_employees(db).await?;
+
+    Ok(result)
+}

--- a/logipack-core/crates/core-application/src/employees/mod.rs
+++ b/logipack-core/crates/core-application/src/employees/mod.rs
@@ -1,0 +1,5 @@
+pub mod create;
+pub mod delete;
+pub mod get;
+pub mod list;
+pub mod update;

--- a/logipack-core/crates/core-application/src/employees/update.rs
+++ b/logipack-core/crates/core-application/src/employees/update.rs
@@ -1,0 +1,49 @@
+use core_data::repository::employees_repo::{self, EmployeeError};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::actor::ActorContext;
+use crate::validation::employee::{EmployeeValidationError, validate_full_name};
+
+#[derive(Debug, Clone)]
+pub struct UpdateEmployee {
+    pub id: Uuid,
+    pub full_name: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum UpdateEmployeeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("validation error: {0}")]
+    Validation(#[from] EmployeeValidationError),
+    #[error("not found")]
+    NotFound,
+    #[error("{0}")]
+    EmployeeError(EmployeeError),
+}
+
+pub async fn update_employee(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    input: UpdateEmployee,
+) -> Result<Uuid, UpdateEmployeeError> {
+    // Only admin can update employees
+    if !actor.is_admin() {
+        return Err(UpdateEmployeeError::Forbidden);
+    }
+
+    if let Some(ref full_name) = input.full_name {
+        validate_full_name(full_name)?;
+    }
+
+    employees_repo::EmployeesRepo::update_employee(db, input.id, input.full_name)
+        .await
+        .map_err(|e| match e {
+            EmployeeError::RecordNotFound => UpdateEmployeeError::NotFound,
+            other => UpdateEmployeeError::EmployeeError(other),
+        })?;
+
+    Ok(input.id)
+}

--- a/logipack-core/crates/core-application/src/lib.rs
+++ b/logipack-core/crates/core-application/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod actor;
 pub mod clients;
+pub mod employees;
 pub mod offices;
 pub mod roles;
 pub mod shipments;

--- a/logipack-core/crates/core-application/src/validation/employee.rs
+++ b/logipack-core/crates/core-application/src/validation/employee.rs
@@ -1,0 +1,54 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum EmployeeValidationError {
+    #[error("full name too short")]
+    FullNameTooShort,
+    #[error("full name too long")]
+    FullNameTooLong,
+}
+
+pub fn validate_full_name(full_name: &str) -> Result<(), EmployeeValidationError> {
+    let trimmed = full_name.trim();
+    let len = trimmed.chars().count();
+
+    if len < 2 {
+        return Err(EmployeeValidationError::FullNameTooShort);
+    }
+
+    if len > 100 {
+        return Err(EmployeeValidationError::FullNameTooLong);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_full_name() {
+        let result = validate_full_name("John Doe");
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn empty_full_name_rejected() {
+        let result = validate_full_name("   ");
+        assert_eq!(result, Err(EmployeeValidationError::FullNameTooShort));
+    }
+
+    #[test]
+    fn short_full_name_rejected() {
+        let result = validate_full_name("A");
+        assert_eq!(result, Err(EmployeeValidationError::FullNameTooShort));
+    }
+
+    #[test]
+    fn long_full_name_rejected() {
+        let name = "a".repeat(101);
+        let result = validate_full_name(&name);
+        assert_eq!(result, Err(EmployeeValidationError::FullNameTooLong));
+    }
+}

--- a/logipack-core/crates/core-application/src/validation/mod.rs
+++ b/logipack-core/crates/core-application/src/validation/mod.rs
@@ -1,2 +1,3 @@
 pub mod client;
+pub mod employee;
 pub mod office;

--- a/logipack-core/crates/core-application/tests/employees_usecases.rs
+++ b/logipack-core/crates/core-application/tests/employees_usecases.rs
@@ -1,0 +1,588 @@
+use core_application::actor::ActorContext;
+use core_application::employees::create::{CreateEmployee, CreateEmployeeError, create_employee};
+use core_application::employees::delete::{DeleteEmployeeError, delete_employee};
+use core_application::employees::get::{GetEmployeeError, get_employee};
+use core_application::employees::list::ListEmployeesError;
+use core_application::employees::update::{UpdateEmployee, UpdateEmployeeError, update_employee};
+use core_application::roles::Role;
+use core_data::entity::{employees, users};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, DatabaseConnection, DbBackend, Set, Statement};
+use test_infra::test_db;
+use uuid::Uuid;
+
+async fn cleanup(db: &DatabaseConnection) {
+    let tables = [
+        "shipment_status_history",
+        "shipments",
+        "employee_offices",
+        "employees",
+        "user_roles",
+        "users",
+        "clients",
+        "roles",
+        "offices",
+        "packages",
+        "streams",
+    ];
+
+    for t in tables {
+        db.execute(Statement::from_string(
+            DbBackend::Postgres,
+            format!("DELETE FROM {}", t),
+        ))
+        .await
+        .unwrap();
+    }
+}
+
+async fn seed_user(db: &DatabaseConnection, user_type: Option<String>) -> Uuid {
+    let id = Uuid::new_v4();
+    let email = match user_type {
+        Some(t) => format!("{}+{}@test.com", t, id),
+        None => format!("{}+{}@test.com", "user_any", id),
+    };
+
+    users::ActiveModel {
+        id: Set(id),
+        email: Set(Some(email)),
+        password_hash: Set(Some("x".into())),
+        auth0_sub: Set(None),
+        created_at: Set(chrono::Utc::now().into()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+async fn seed_employee_record(db: &DatabaseConnection, user_id: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+
+    employees::ActiveModel {
+        id: Set(id),
+        user_id: Set(user_id),
+        full_name: Set("Test Employee".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+async fn admin_actor(db: &DatabaseConnection) -> ActorContext {
+    let user_id = seed_user(db, Some("admin".to_string())).await;
+
+    ActorContext {
+        user_id,
+        sub: "admin".into(),
+        roles: vec![Role::Admin],
+        employee_id: None,
+        allowed_office_ids: vec![],
+    }
+}
+
+async fn employee_actor(db: &DatabaseConnection) -> ActorContext {
+    let user_id = seed_user(db, Some("employee".to_string())).await;
+    let employee_id = seed_employee_record(db, user_id).await;
+
+    ActorContext {
+        user_id,
+        sub: "employee".into(),
+        roles: vec![Role::Employee],
+        employee_id: Some(employee_id),
+        allowed_office_ids: vec![],
+    }
+}
+
+async fn no_role_actor(db: &DatabaseConnection) -> ActorContext {
+    let user_id = seed_user(db, None).await;
+
+    ActorContext {
+        user_id,
+        sub: "".into(),
+        roles: vec![],
+        employee_id: None,
+        allowed_office_ids: vec![],
+    }
+}
+
+/* --------------------- */
+/* Create Employee tests */
+/* --------------------- */
+
+#[tokio::test]
+async fn admin_can_create_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+
+    let employee_id = create_employee(
+        &db,
+        &admin,
+        CreateEmployee {
+            user_id,
+            full_name: "Test Employee".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = get_employee(&db, &admin, employee_id).await.unwrap();
+    assert!(result.is_some());
+
+    let result = result.unwrap();
+    assert_eq!(result.full_name, "Test Employee".to_string());
+    assert_eq!(result.user_id, user_id);
+}
+
+#[tokio::test]
+async fn employee_cannot_create_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+
+    let result = create_employee(
+        &db,
+        &employee,
+        CreateEmployee {
+            user_id,
+            full_name: "Test Employee".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, CreateEmployeeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_create_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+
+    let result = create_employee(
+        &db,
+        &user,
+        CreateEmployee {
+            user_id,
+            full_name: "Test Employee".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, CreateEmployeeError::Forbidden));
+}
+
+#[tokio::test]
+async fn invalid_employee_data_cannot_create() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+
+    let invalid_name = create_employee(
+        &db,
+        &admin,
+        CreateEmployee {
+            user_id,
+            full_name: "".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(invalid_name, CreateEmployeeError::Validation(_)));
+}
+
+/* --------------------- */
+/* Update Employee tests */
+/* --------------------- */
+
+#[tokio::test]
+async fn admin_can_update_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    let updated_id = update_employee(
+        &db,
+        &admin,
+        UpdateEmployee {
+            id: employee_id,
+            full_name: Some("Updated Employee".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = get_employee(&db, &admin, updated_id).await.unwrap();
+    assert!(result.is_some());
+
+    let result = result.unwrap();
+    assert_eq!(result.full_name, "Updated Employee".to_string());
+}
+
+#[tokio::test]
+async fn employee_cannot_update_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    let result = update_employee(
+        &db,
+        &employee,
+        UpdateEmployee {
+            id: employee_id,
+            full_name: Some("Updated Employee".to_string()),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, UpdateEmployeeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_update_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    let result = update_employee(
+        &db,
+        &user,
+        UpdateEmployee {
+            id: employee_id,
+            full_name: Some("Updated Employee".to_string()),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, UpdateEmployeeError::Forbidden));
+}
+
+#[tokio::test]
+async fn invalid_employee_data_cannot_update() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    let invalid_name = update_employee(
+        &db,
+        &admin,
+        UpdateEmployee {
+            id: employee_id,
+            full_name: Some("".to_string()),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(invalid_name, UpdateEmployeeError::Validation(_)));
+}
+
+#[tokio::test]
+async fn updating_nonexistent_employee_returns_error() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let result = update_employee(
+        &db,
+        &admin,
+        UpdateEmployee {
+            id: Uuid::new_v4(),
+            full_name: Some("Updated Employee".to_string()),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, UpdateEmployeeError::NotFound));
+}
+
+#[tokio::test]
+async fn updating_deleted_employee_returns_error() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    delete_employee(&db, &admin, employee_id).await.unwrap();
+
+    let result = update_employee(
+        &db,
+        &admin,
+        UpdateEmployee {
+            id: employee_id,
+            full_name: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, UpdateEmployeeError::NotFound));
+}
+
+/* --------------------- */
+/* Delete Employee tests */
+/* --------------------- */
+
+#[tokio::test]
+async fn admin_can_delete_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    delete_employee(&db, &admin, employee_id).await.unwrap();
+
+    let result = get_employee(&db, &admin, employee_id).await.unwrap_err();
+    assert!(matches!(result, GetEmployeeError::NotFound));
+}
+
+#[tokio::test]
+async fn employee_cannot_delete_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    let result = delete_employee(&db, &employee, employee_id)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, DeleteEmployeeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_delete_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    let result = delete_employee(&db, &user, employee_id).await.unwrap_err();
+
+    assert!(matches!(result, DeleteEmployeeError::Forbidden));
+}
+
+#[tokio::test]
+async fn deleting_nonexistent_employee_returns_error() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let result = delete_employee(&db, &admin, Uuid::new_v4())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, DeleteEmployeeError::NotFound));
+}
+
+#[tokio::test]
+async fn deleting_already_deleted_employee_returns_error() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    delete_employee(&db, &admin, employee_id).await.unwrap();
+
+    let result = delete_employee(&db, &admin, employee_id).await.unwrap_err();
+
+    assert!(matches!(result, DeleteEmployeeError::NotFound));
+}
+
+/* ------------------ */
+/* Get Employee tests */
+/* ------------------ */
+
+#[tokio::test]
+async fn admin_can_get_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    let result = get_employee(&db, &admin, employee_id).await.unwrap();
+    assert!(result.is_some());
+
+    let result = result.unwrap();
+    assert_eq!(result.full_name, "Test Employee".to_string());
+    assert_eq!(result.user_id, user_id);
+}
+
+#[tokio::test]
+async fn employee_cannot_get_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    let result = get_employee(&db, &employee, employee_id).await.unwrap_err();
+
+    assert!(matches!(result, GetEmployeeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_get_employee() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+    let user_id = seed_user(&db, Some("user".to_string())).await;
+    let employee_id = seed_employee_record(&db, user_id).await;
+
+    let result = get_employee(&db, &user, employee_id).await.unwrap_err();
+
+    assert!(matches!(result, GetEmployeeError::Forbidden));
+}
+
+#[tokio::test]
+async fn getting_nonexistent_employee_returns_not_found() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let result = get_employee(&db, &admin, Uuid::new_v4()).await.unwrap_err();
+
+    assert!(matches!(result, GetEmployeeError::NotFound));
+}
+
+/* ------------------- */
+/* List Employees test */
+/* ------------------- */
+
+#[tokio::test]
+async fn admin_can_list_employees() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    for i in 0..5 {
+        let user_id = seed_user(&db, Some(format!("user_{i}"))).await;
+        create_employee(
+            &db,
+            &admin,
+            CreateEmployee {
+                user_id,
+                full_name: format!("Employee {}", i),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let result = core_application::employees::list::list_employees(&db, &admin)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 5);
+}
+
+#[tokio::test]
+async fn employee_cannot_list_employees() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+    let admin = admin_actor(&db).await;
+
+    for i in 0..5 {
+        let user_id = seed_user(&db, Some(format!("user_{i}"))).await;
+        create_employee(
+            &db,
+            &admin,
+            CreateEmployee {
+                user_id,
+                full_name: format!("Employee {}", i),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let result = core_application::employees::list::list_employees(&db, &employee)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, ListEmployeesError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_list_employees() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+    let admin = admin_actor(&db).await;
+
+    for i in 0..5 {
+        let user_id = seed_user(&db, Some(format!("user_{i}"))).await;
+        create_employee(
+            &db,
+            &admin,
+            CreateEmployee {
+                user_id,
+                full_name: format!("Employee {}", i),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let result = core_application::employees::list::list_employees(&db, &user)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, ListEmployeesError::Forbidden));
+}

--- a/logipack-core/crates/core-data/src/repository/employees_repo.rs
+++ b/logipack-core/crates/core-data/src/repository/employees_repo.rs
@@ -1,0 +1,108 @@
+use sea_orm::ActiveValue::Set;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, DbErr, EntityTrait, IntoActiveModel,
+    QueryFilter,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::entity::employees;
+
+#[derive(Debug, Error)]
+pub enum EmployeeError {
+    #[error("db error: {0}")]
+    EmployeeDbError(#[from] DbErr),
+    #[error("employee not found")]
+    RecordNotFound,
+}
+
+pub struct EmployeesRepo;
+
+impl EmployeesRepo {
+    /// Creates a new employee
+    pub async fn create_employee(
+        db: &DatabaseConnection,
+        id: Uuid,
+        user_id: Uuid,
+        full_name: String,
+    ) -> Result<(), EmployeeError> {
+        let model = employees::ActiveModel {
+            id: Set(id),
+            user_id: Set(user_id),
+            full_name: Set(full_name),
+            created_at: Set(chrono::Utc::now().into()),
+            updated_at: Set(chrono::Utc::now().into()),
+            deleted_at: Set(None),
+        };
+
+        model.insert(db).await?;
+        Ok(())
+    }
+
+    /// Gets employee by id
+    pub async fn get_employee_by_id(
+        db: &DatabaseConnection,
+        id: Uuid,
+    ) -> Result<Option<employees::Model>, EmployeeError> {
+        let retrieved = employees::Entity::find_by_id(id).one(db).await?;
+
+        if retrieved.is_none() || retrieved.as_ref().unwrap().deleted_at.is_some() {
+            return Err(EmployeeError::RecordNotFound);
+        }
+
+        Ok(retrieved)
+    }
+
+    /// Lists all employees
+    pub async fn list_employees(
+        db: &DatabaseConnection,
+    ) -> Result<Vec<employees::Model>, EmployeeError> {
+        let retrieved = employees::Entity::find()
+            .filter(employees::Column::DeletedAt.is_null())
+            .all(db)
+            .await?;
+        Ok(retrieved)
+    }
+
+    /// Updates an employee's information
+    pub async fn update_employee(
+        db: &DatabaseConnection,
+        id: Uuid,
+        full_name: Option<String>,
+    ) -> Result<(), EmployeeError> {
+        let mut model = employees::Entity::find_by_id(id)
+            .filter(employees::Column::DeletedAt.is_null())
+            .one(db)
+            .await?
+            .ok_or(EmployeeError::RecordNotFound)?
+            .into_active_model();
+
+        if let Some(full_name) = full_name {
+            model.full_name = Set(full_name);
+        }
+
+        model.updated_at = Set(chrono::Utc::now().into());
+
+        model.update(db).await?;
+        Ok(())
+    }
+
+    /// Soft deletes an employee by id
+    pub async fn delete_employee(db: &DatabaseConnection, id: Uuid) -> Result<(), EmployeeError> {
+        let result = employees::Entity::update_many()
+            .col_expr(
+                employees::Column::DeletedAt,
+                sea_orm::sea_query::Expr::cust("NOW()"),
+            )
+            .filter(employees::Column::Id.eq(id))
+            .filter(employees::Column::DeletedAt.is_null())
+            .exec(db)
+            .await?;
+
+        if result.rows_affected == 0 {
+            return Err(EmployeeError::RecordNotFound);
+        }
+
+        Ok(())
+    }
+}

--- a/logipack-core/crates/core-data/src/repository/mod.rs
+++ b/logipack-core/crates/core-data/src/repository/mod.rs
@@ -1,3 +1,4 @@
 pub mod clients_repo;
+pub mod employees_repo;
 pub mod offices_repo;
 pub mod shipments_repo;

--- a/logipack-core/crates/core-data/tests/employees_repo.rs
+++ b/logipack-core/crates/core-data/tests/employees_repo.rs
@@ -1,0 +1,193 @@
+use sea_orm::{
+    ActiveModelTrait, ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, Set, Statement,
+};
+use uuid::Uuid;
+
+use core_data::entity::{employees, users};
+use core_data::repository::employees_repo::{EmployeeError, EmployeesRepo};
+use test_infra::test_db;
+
+pub async fn seed_user(db: &DatabaseConnection) -> Uuid {
+    let id = Uuid::new_v4();
+
+    users::ActiveModel {
+        id: Set(id),
+        email: Set(Some(format!("user+{id}@test.com"))),
+        password_hash: Set(Some("x".into())),
+        auth0_sub: Set(None),
+        created_at: Set(chrono::Utc::now().into()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+pub async fn cleanup_core_data(db: &DatabaseConnection) {
+    let tables = [
+        "shipment_status_history",
+        "shipments",
+        "employee_offices",
+        "employees",
+        "user_roles",
+        "users",
+        "clients",
+        "roles",
+        "offices",
+    ];
+
+    for t in tables {
+        db.execute(Statement::from_string(
+            DbBackend::Postgres,
+            format!("DELETE FROM {}", t),
+        ))
+        .await
+        .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn create_inserts_row_with_null_deleted_at() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let id = Uuid::new_v4();
+    let user_id = seed_user(&db).await;
+
+    EmployeesRepo::create_employee(&db, id, user_id, "Test Employee".into())
+        .await
+        .unwrap();
+
+    let row = employees::Entity::find_by_id(id).one(&db).await.unwrap();
+    assert!(row.is_some());
+    assert!(row.unwrap().deleted_at.is_none());
+}
+
+#[tokio::test]
+async fn list_returns_only_non_deleted_rows() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let user_id_1 = seed_user(&db).await;
+    let user_id_2 = seed_user(&db).await;
+
+    let id_1 = Uuid::new_v4();
+    let id_2 = Uuid::new_v4();
+
+    EmployeesRepo::create_employee(&db, id_1, user_id_1, "Employee 1".into())
+        .await
+        .unwrap();
+    EmployeesRepo::create_employee(&db, id_2, user_id_2, "Employee 2".into())
+        .await
+        .unwrap();
+
+    EmployeesRepo::delete_employee(&db, id_1).await.unwrap();
+
+    let rows = EmployeesRepo::list_employees(&db).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, id_2);
+}
+
+#[tokio::test]
+async fn get_returns_record_not_found_for_soft_deleted() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let user_id = seed_user(&db).await;
+    let id = Uuid::new_v4();
+
+    EmployeesRepo::create_employee(&db, id, user_id, "Employee".into())
+        .await
+        .unwrap();
+    EmployeesRepo::delete_employee(&db, id).await.unwrap();
+
+    let result = EmployeesRepo::get_employee_by_id(&db, id)
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeError::RecordNotFound));
+}
+
+#[tokio::test]
+async fn delete_sets_deleted_at_and_reflects_in_get_list() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let user_id = seed_user(&db).await;
+    let id = Uuid::new_v4();
+
+    EmployeesRepo::create_employee(&db, id, user_id, "Employee".into())
+        .await
+        .unwrap();
+
+    EmployeesRepo::delete_employee(&db, id).await.unwrap();
+
+    let result = EmployeesRepo::get_employee_by_id(&db, id)
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeError::RecordNotFound));
+
+    let rows = EmployeesRepo::list_employees(&db).await.unwrap();
+    assert!(rows.is_empty());
+}
+
+#[tokio::test]
+async fn delete_already_deleted_returns_record_not_found() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let user_id = seed_user(&db).await;
+    let id = Uuid::new_v4();
+
+    EmployeesRepo::create_employee(&db, id, user_id, "Employee".into())
+        .await
+        .unwrap();
+    EmployeesRepo::delete_employee(&db, id).await.unwrap();
+
+    let result = EmployeesRepo::delete_employee(&db, id).await.unwrap_err();
+    assert!(matches!(result, EmployeeError::RecordNotFound));
+}
+
+#[tokio::test]
+async fn update_updates_updated_at_does_not_resurrect_deleted() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let user_id = seed_user(&db).await;
+    let id = Uuid::new_v4();
+
+    EmployeesRepo::create_employee(&db, id, user_id, "Employee".into())
+        .await
+        .unwrap();
+    EmployeesRepo::delete_employee(&db, id).await.unwrap();
+
+    let result = EmployeesRepo::update_employee(&db, id, Some("Updated".into()))
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeError::RecordNotFound));
+
+    let user_id_2 = seed_user(&db).await;
+    let id_2 = Uuid::new_v4();
+
+    EmployeesRepo::create_employee(&db, id_2, user_id_2, "Employee".into())
+        .await
+        .unwrap();
+
+    let before = employees::Entity::find_by_id(id_2)
+        .one(&db)
+        .await
+        .unwrap()
+        .unwrap();
+
+    EmployeesRepo::update_employee(&db, id_2, Some("Updated".into()))
+        .await
+        .unwrap();
+
+    let after = employees::Entity::find_by_id(id_2)
+        .one(&db)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert!(after.updated_at > before.updated_at);
+}

--- a/logipack-hub/hub-api/src/dto/employees.rs
+++ b/logipack-hub/hub-api/src/dto/employees.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EmployeeDto {
+    pub id: String,
+    pub user_id: String,
+    pub full_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateEmployeeRequest {
+    pub user_id: String,
+    pub full_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateEmployeeResponse {
+    pub employee_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListEmployeesResponse {
+    pub employees: Vec<EmployeeDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetEmployeeResponse {
+    pub employee: EmployeeDto,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateEmployeeRequest {
+    pub full_name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateEmployeeResponse {
+    pub employee_id: String,
+}

--- a/logipack-hub/hub-api/src/dto/mod.rs
+++ b/logipack-hub/hub-api/src/dto/mod.rs
@@ -1,3 +1,4 @@
 pub mod clients;
+pub mod employees;
 pub mod offices;
 pub mod shipments;

--- a/logipack-hub/hub-api/src/routes/admin.rs
+++ b/logipack-hub/hub-api/src/routes/admin.rs
@@ -1,5 +1,5 @@
 use crate::{
-    routes::admin_ep::{clients, offices},
+    routes::admin_ep::{clients, employees, offices},
     state::AppState,
 };
 use axum::Router;
@@ -7,5 +7,6 @@ use axum::Router;
 pub fn router() -> Router<AppState> {
     Router::new()
         .nest("/clients", clients::router())
+        .nest("/employees", employees::router())
         .nest("/offices", offices::router())
 }

--- a/logipack-hub/hub-api/src/routes/admin_ep/employees.rs
+++ b/logipack-hub/hub-api/src/routes/admin_ep/employees.rs
@@ -1,0 +1,214 @@
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    routing::{delete, get, post, put},
+};
+use core_application::actor::ActorContext;
+
+use crate::{
+    dto::employees::{
+        CreateEmployeeRequest, CreateEmployeeResponse, EmployeeDto, GetEmployeeResponse,
+        ListEmployeesResponse, UpdateEmployeeRequest, UpdateEmployeeResponse,
+    },
+    error::ApiError,
+    policy,
+    state::AppState,
+};
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_employees_handler))
+        .route("/:id", get(get_employee_handler))
+        .route("/", post(create_employee_handler))
+        .route("/:id", put(update_employee_handler))
+        .route("/:id", delete(delete_employee_handler))
+}
+
+async fn list_employees_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+) -> Result<Json<ListEmployeesResponse>, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let out = core_application::employees::list::list_employees(&state.db, &actor)
+        .await
+        .map_err(|e| match e {
+            core_application::employees::list::ListEmployeesError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::employees::list::ListEmployeesError::EmployeeError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    let dtos: Vec<EmployeeDto> = out
+        .into_iter()
+        .map(|employee| EmployeeDto {
+            id: employee.id.to_string(),
+            user_id: employee.user_id.to_string(),
+            full_name: employee.full_name,
+        })
+        .collect();
+
+    let result = ListEmployeesResponse { employees: dtos };
+
+    Ok(Json(result))
+}
+
+async fn get_employee_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Path(id): Path<String>,
+) -> Result<Json<GetEmployeeResponse>, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let employee_uuid = id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_employee_id", "Employee ID must be a valid UUID")
+    })?;
+
+    let out = core_application::employees::get::get_employee(&state.db, &actor, employee_uuid)
+        .await
+        .map_err(|e| match e {
+            core_application::employees::get::GetEmployeeError::NotFound => {
+                ApiError::not_found("employee_not_found", "Employee not found")
+            }
+            core_application::employees::get::GetEmployeeError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::employees::get::GetEmployeeError::EmployeeError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    let employee =
+        out.ok_or_else(|| ApiError::not_found("employee_not_found", "Employee not found"))?;
+    let result = GetEmployeeResponse {
+        employee: EmployeeDto {
+            id: employee.id.to_string(),
+            user_id: employee.user_id.to_string(),
+            full_name: employee.full_name,
+        },
+    };
+
+    Ok(Json(result))
+}
+
+async fn create_employee_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Json(request): Json<CreateEmployeeRequest>,
+) -> Result<(axum::http::StatusCode, Json<CreateEmployeeResponse>), ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let user_id = request
+        .user_id
+        .parse::<uuid::Uuid>()
+        .map_err(|_| ApiError::bad_request("invalid_user_id", "User ID must be a valid UUID"))?;
+
+    let input = core_application::employees::create::CreateEmployee {
+        user_id,
+        full_name: request.full_name,
+    };
+
+    let employee_id =
+        core_application::employees::create::create_employee(&state.db, &actor, input)
+            .await
+            .map_err(|e| match e {
+                core_application::employees::create::CreateEmployeeError::Forbidden => {
+                    ApiError::forbidden("access_denied", "Access denied")
+                }
+                core_application::employees::create::CreateEmployeeError::Validation(err) => {
+                    ApiError::bad_request("invalid_employee", err.to_string())
+                }
+                core_application::employees::create::CreateEmployeeError::EmployeeCreationError(
+                    err,
+                ) => match err {
+                    core_data::repository::employees_repo::EmployeeError::EmployeeDbError(
+                        db_err,
+                    ) => db_err.into(),
+                    core_data::repository::employees_repo::EmployeeError::RecordNotFound => {
+                        ApiError::internal(err.to_string())
+                    }
+                },
+            })?;
+
+    let result = CreateEmployeeResponse {
+        employee_id: employee_id.to_string(),
+    };
+
+    Ok((axum::http::StatusCode::CREATED, Json(result)))
+}
+
+async fn update_employee_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Path(id): Path<String>,
+    Json(request): Json<UpdateEmployeeRequest>,
+) -> Result<Json<UpdateEmployeeResponse>, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let employee_uuid = id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_employee_id", "Employee ID must be a valid UUID")
+    })?;
+
+    let input = core_application::employees::update::UpdateEmployee {
+        id: employee_uuid,
+        full_name: request.full_name,
+    };
+
+    let out = core_application::employees::update::update_employee(&state.db, &actor, input)
+        .await
+        .map_err(|e| match e {
+            core_application::employees::update::UpdateEmployeeError::NotFound => {
+                ApiError::not_found("employee_not_found", "Employee not found")
+            }
+            core_application::employees::update::UpdateEmployeeError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::employees::update::UpdateEmployeeError::Validation(err) => {
+                ApiError::bad_request("invalid_employee", err.to_string())
+            }
+            core_application::employees::update::UpdateEmployeeError::EmployeeError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    let result = UpdateEmployeeResponse {
+        employee_id: out.to_string(),
+    };
+
+    Ok(Json(result))
+}
+
+async fn delete_employee_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Path(id): Path<String>,
+) -> Result<axum::http::StatusCode, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let employee_uuid = id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_employee_id", "Employee ID must be a valid UUID")
+    })?;
+
+    core_application::employees::delete::delete_employee(&state.db, &actor, employee_uuid)
+        .await
+        .map_err(|e| match e {
+            core_application::employees::delete::DeleteEmployeeError::NotFound => {
+                ApiError::not_found("employee_not_found", "Employee not found")
+            }
+            core_application::employees::delete::DeleteEmployeeError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::employees::delete::DeleteEmployeeError::EmployeeError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}

--- a/logipack-hub/hub-api/src/routes/admin_ep/mod.rs
+++ b/logipack-hub/hub-api/src/routes/admin_ep/mod.rs
@@ -1,2 +1,3 @@
 pub mod clients;
+pub mod employees;
 pub mod offices;

--- a/logipack-hub/hub-api/tests/employees.rs
+++ b/logipack-hub/hub-api/tests/employees.rs
@@ -1,0 +1,17 @@
+#[path = "helpers.rs"]
+pub mod helpers;
+
+#[path = "employees/employees_create.rs"]
+mod employees_create;
+
+#[path = "employees/employees_get.rs"]
+mod employees_get;
+
+#[path = "employees/employees_list.rs"]
+mod employees_list;
+
+#[path = "employees/employees_update.rs"]
+mod employees_update;
+
+#[path = "employees/employees_delete.rs"]
+mod employees_delete;

--- a/logipack-hub/hub-api/tests/employees/employees_create.rs
+++ b/logipack-hub/hub-api/tests/employees/employees_create.rs
@@ -1,0 +1,125 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+};
+use http_body_util::BodyExt;
+use hub_api::dto::employees::CreateEmployeeResponse;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::helpers::{
+    seed_employee, seed_user_for_employee, setup_app_with_admin, setup_app_with_db,
+};
+
+#[tokio::test]
+async fn admin_can_create_employee() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let user_id = seed_user_for_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri("/admin/employees")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "user_id": user_id.to_string(),
+                        "full_name": "Test Employee",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::CREATED);
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: CreateEmployeeResponse = serde_json::from_slice(&body).unwrap();
+    let employee_id = Uuid::parse_str(&body.employee_id).unwrap();
+
+    assert_ne!(employee_id, Uuid::nil());
+}
+
+#[tokio::test]
+async fn employee_cannot_create_employee() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+    let user_id = seed_user_for_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri("/admin/employees")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "user_id": user_id.to_string(),
+                        "full_name": "Test Employee",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_create_employee() {
+    let (app, db) = setup_app_with_db().await;
+    let user_id = seed_user_for_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri("/admin/employees")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "user_id": user_id.to_string(),
+                        "full_name": "Test Employee",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn create_employee_invalid_json() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri("/admin/employees")
+                .body(Body::from("{invalid"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}

--- a/logipack-hub/hub-api/tests/employees/employees_delete.rs
+++ b/logipack-hub/hub-api/tests/employees/employees_delete.rs
@@ -1,0 +1,114 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::helpers::{
+    seed_employee, seed_employee_record, setup_app_with_admin, setup_app_with_db,
+};
+
+#[tokio::test]
+async fn admin_can_delete_employee() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!("/admin/employees/{}", employee_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn admin_delete_employee_invalid_uuid() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri("/admin/employees/not-a-uuid")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn admin_delete_employee_not_found() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!("/admin/employees/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn employee_cannot_delete_employee() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!("/admin/employees/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_delete_employee() {
+    let (app, db) = setup_app_with_db().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .method(Method::DELETE)
+                .uri(format!("/admin/employees/{}", employee_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/logipack-hub/hub-api/tests/employees/employees_get.rs
+++ b/logipack-hub/hub-api/tests/employees/employees_get.rs
@@ -1,0 +1,112 @@
+use axum::{body::Body, extract::Request, http::StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use hub_api::dto::employees::GetEmployeeResponse;
+
+use crate::helpers::{
+    seed_employee, seed_employee_record, setup_app_with_admin, setup_app_with_db,
+};
+
+#[tokio::test]
+async fn admin_can_get_employee() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri(format!("/admin/employees/{}", employee_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: GetEmployeeResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(body.employee.id, employee_id.to_string());
+}
+
+#[tokio::test]
+async fn admin_get_employee_invalid_uuid() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri("/admin/employees/not-a-uuid")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn admin_get_employee_not_found() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri(format!("/admin/employees/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn employee_cannot_get_employee() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .uri(format!("/admin/employees/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_get_employee() {
+    let (app, _db) = setup_app_with_db().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .uri(format!("/admin/employees/{}", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/logipack-hub/hub-api/tests/employees/employees_list.rs
+++ b/logipack-hub/hub-api/tests/employees/employees_list.rs
@@ -1,0 +1,99 @@
+use axum::{body::Body, extract::Request, http::StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use hub_api::dto::employees::ListEmployeesResponse;
+
+use crate::helpers::{
+    seed_employee, seed_employee_record, setup_app_with_admin, setup_app_with_db,
+};
+
+#[tokio::test]
+async fn list_employees_empty() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri("/admin/employees")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: ListEmployeesResponse = serde_json::from_slice(&body).unwrap();
+
+    assert!(body.employees.is_empty());
+}
+
+#[tokio::test]
+async fn list_employees_returns_rows() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri("/admin/employees")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: ListEmployeesResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(body.employees.len(), 1);
+    assert_eq!(body.employees[0].id, employee_id.to_string());
+}
+
+#[tokio::test]
+async fn employee_cannot_list_employees() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .uri("/admin/employees")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_list_employees() {
+    let (app, _db) = setup_app_with_db().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .uri("/admin/employees")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/logipack-hub/hub-api/tests/employees/employees_update.rs
+++ b/logipack-hub/hub-api/tests/employees/employees_update.rs
@@ -1,0 +1,175 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use hub_api::dto::employees::UpdateEmployeeResponse;
+
+use crate::helpers::{
+    seed_employee, seed_employee_record, setup_app_with_admin, setup_app_with_db,
+};
+
+#[tokio::test]
+async fn admin_can_update_employee() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/employees/{}", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "full_name": "Updated Employee"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: UpdateEmployeeResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(body.employee_id, employee_id.to_string());
+}
+
+#[tokio::test]
+async fn admin_update_employee_invalid_uuid() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri("/admin/employees/not-a-uuid")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "full_name": "Updated Employee"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn admin_update_employee_not_found() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/employees/{}", Uuid::new_v4()))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "full_name": "Updated Employee"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn admin_update_employee_invalid_json() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/employees/{}", Uuid::new_v4()))
+                .body(Body::from("{invalid"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn employee_cannot_update_employee() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/employees/{}", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "full_name": "Updated Employee"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_update_employee() {
+    let (app, db) = setup_app_with_db().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .header("content-type", "application/json")
+                .method(Method::PUT)
+                .uri(format!("/admin/employees/{}", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "full_name": "Updated Employee"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/logipack-hub/hub-api/tests/helpers.rs
+++ b/logipack-hub/hub-api/tests/helpers.rs
@@ -475,6 +475,48 @@ pub async fn seed_office(db: &DatabaseConnection) -> Uuid {
     id
 }
 
+pub async fn seed_employee_record(db: &DatabaseConnection) -> Uuid {
+    use core_data::entity::employees;
+    use sea_orm::{ActiveModelTrait, Set};
+
+    let user_id = seed_user_for_employee(db).await;
+    let id = Uuid::new_v4();
+
+    employees::ActiveModel {
+        id: Set(id),
+        user_id: Set(user_id),
+        full_name: Set("Test Employee".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+pub async fn seed_user_for_employee(db: &DatabaseConnection) -> Uuid {
+    use core_data::entity::users;
+    use sea_orm::{ActiveModelTrait, Set};
+
+    let id = Uuid::new_v4();
+
+    users::ActiveModel {
+        id: Set(id),
+        email: Set(Some(format!("user+{}@test.com", id))),
+        auth0_sub: Set(None),
+        password_hash: Set(Some("x".into())),
+        created_at: Set(chrono::Utc::now().into()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
 pub async fn setup_app_with_admin() -> (Router, DatabaseConnection, ActorContext) {
     let db = test_db().await;
 


### PR DESCRIPTION
## Summary

Implements **admin-only Employees CRUD** across the stack:

- **core-application** usecases: `create/get/list/update/delete`
- **core-data** repository: `EmployeesRepo` with **soft delete** (`deleted_at`)
- **hub-api** admin endpoints + DTOs under `/admin/employees`
- Adds thorough test coverage in **core-application**, **core-data**, and **hub-api**

Closes #4 

## Endpoints

- `POST /admin/employees` → **201**
- `GET /admin/employees` → **200**
- `GET /admin/employees/:id` → **200**
- `PUT /admin/employees/:id` → **200**
- `DELETE /admin/employees/:id` → **204**

## Behavior & Rules

- **Admin-only** access enforced (edge policy + usecase guard)
- **Soft delete**
  - Delete sets `deleted_at`
  - Get/List exclude deleted rows
  - Update on deleted returns NotFound
- **Validation**
  - `full_name` trimmed length **2..=100**
- **ID parsing**
  - invalid UUIDs return **400**

## Tests

- **core-application**: access control + validation + not found + deleted behavior
- **core-data**: repo CRUD semantics + soft delete invariants + updated_at behavior
- **hub-api**: endpoint status codes + auth behavior + invalid UUID/JSON cases

## Notes

- Create relies on DB constraints for invalid `user_id` (FK), and DB errors bubble up via existing error mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added employee management system with admin-only access control
* Create, update, retrieve, and delete individual employee records
* List all employees with proper authorization enforcement
* Employee name validation with length constraints (2-100 characters)
* REST API endpoints for comprehensive employee operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->