### PR TITLE
feat(admin): add employee <-> office assignment endpoints + repo + tests

### DIFF
--- a/logipack-core/crates/core-application/src/employee_offices/assign.rs
+++ b/logipack-core/crates/core-application/src/employee_offices/assign.rs
@@ -1,0 +1,50 @@
+use core_data::repository::employee_offices_repo::{EmployeeOfficeError, EmployeeOfficesRepo};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::actor::ActorContext;
+
+#[derive(Debug, Clone)]
+pub struct AssignOffice {
+    pub employee_id: Uuid,
+    pub office_id: Uuid,
+}
+
+#[derive(Debug, Error)]
+pub enum AssignOfficeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("employee not found")]
+    EmployeeNotFound,
+    #[error("office not found")]
+    OfficeNotFound,
+    #[error("employee already assigned to office")]
+    AlreadyAssigned,
+    #[error("{0}")]
+    AssignError(#[from] EmployeeOfficeError),
+}
+
+pub async fn assign_office(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    input: AssignOffice,
+) -> Result<(), AssignOfficeError> {
+    if !actor.is_admin() {
+        return Err(AssignOfficeError::Forbidden);
+    }
+
+    let inserted = EmployeeOfficesRepo::assign_office(db, input.employee_id, input.office_id)
+        .await
+        .map_err(|e| match e {
+            EmployeeOfficeError::EmployeeNotFound => AssignOfficeError::EmployeeNotFound,
+            EmployeeOfficeError::OfficeNotFound => AssignOfficeError::OfficeNotFound,
+            other => AssignOfficeError::AssignError(other),
+        })?;
+
+    if !inserted {
+        return Err(AssignOfficeError::AlreadyAssigned);
+    }
+
+    Ok(())
+}

--- a/logipack-core/crates/core-application/src/employee_offices/list.rs
+++ b/logipack-core/crates/core-application/src/employee_offices/list.rs
@@ -1,0 +1,35 @@
+use core_data::repository::employee_offices_repo::{EmployeeOfficeError, EmployeeOfficesRepo};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::actor::ActorContext;
+
+#[derive(Debug, Error)]
+pub enum ListEmployeeOfficesError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("employee not found")]
+    EmployeeNotFound,
+    #[error("{0}")]
+    ListError(#[from] EmployeeOfficeError),
+}
+
+pub async fn list_employee_offices(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    employee_id: Uuid,
+) -> Result<Vec<Uuid>, ListEmployeeOfficesError> {
+    if !actor.is_admin() {
+        return Err(ListEmployeeOfficesError::Forbidden);
+    }
+
+    let office_ids = EmployeeOfficesRepo::list_offices(db, employee_id)
+        .await
+        .map_err(|e| match e {
+            EmployeeOfficeError::EmployeeNotFound => ListEmployeeOfficesError::EmployeeNotFound,
+            other => ListEmployeeOfficesError::ListError(other),
+        })?;
+
+    Ok(office_ids)
+}

--- a/logipack-core/crates/core-application/src/employee_offices/mod.rs
+++ b/logipack-core/crates/core-application/src/employee_offices/mod.rs
@@ -1,0 +1,3 @@
+pub mod assign;
+pub mod list;
+pub mod remove;

--- a/logipack-core/crates/core-application/src/employee_offices/remove.rs
+++ b/logipack-core/crates/core-application/src/employee_offices/remove.rs
@@ -1,0 +1,44 @@
+use core_data::repository::employee_offices_repo::{EmployeeOfficeError, EmployeeOfficesRepo};
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::actor::ActorContext;
+
+#[derive(Debug, Clone)]
+pub struct RemoveOffice {
+    pub employee_id: Uuid,
+    pub office_id: Uuid,
+}
+
+#[derive(Debug, Error)]
+pub enum RemoveOfficeError {
+    #[error("forbidden")]
+    Forbidden,
+    #[error("employee not found")]
+    EmployeeNotFound,
+    #[error("office not found")]
+    OfficeNotFound,
+    #[error("{0}")]
+    RemoveError(#[from] EmployeeOfficeError),
+}
+
+pub async fn remove_office(
+    db: &DatabaseConnection,
+    actor: &ActorContext,
+    input: RemoveOffice,
+) -> Result<(), RemoveOfficeError> {
+    if !actor.is_admin() {
+        return Err(RemoveOfficeError::Forbidden);
+    }
+
+    EmployeeOfficesRepo::remove_office(db, input.employee_id, input.office_id)
+        .await
+        .map_err(|e| match e {
+            EmployeeOfficeError::EmployeeNotFound => RemoveOfficeError::EmployeeNotFound,
+            EmployeeOfficeError::OfficeNotFound => RemoveOfficeError::OfficeNotFound,
+            other => RemoveOfficeError::RemoveError(other),
+        })?;
+
+    Ok(())
+}

--- a/logipack-core/crates/core-application/src/lib.rs
+++ b/logipack-core/crates/core-application/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod actor;
 pub mod clients;
+pub mod employee_offices;
 pub mod employees;
 pub mod offices;
 pub mod roles;

--- a/logipack-core/crates/core-application/tests/employee_offices_usecases.rs
+++ b/logipack-core/crates/core-application/tests/employee_offices_usecases.rs
@@ -1,0 +1,547 @@
+use core_application::actor::ActorContext;
+use core_application::employee_offices::assign::{AssignOffice, AssignOfficeError, assign_office};
+use core_application::employee_offices::list::{ListEmployeeOfficesError, list_employee_offices};
+use core_application::employee_offices::remove::{RemoveOffice, RemoveOfficeError, remove_office};
+use core_application::roles::Role;
+use core_data::entity::{employees, offices, users};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, DatabaseConnection, DbBackend, Set, Statement};
+use test_infra::test_db;
+use uuid::Uuid;
+
+async fn cleanup(db: &DatabaseConnection) {
+    let tables = [
+        "shipment_status_history",
+        "shipments",
+        "employee_offices",
+        "employees",
+        "user_roles",
+        "users",
+        "clients",
+        "roles",
+        "offices",
+        "packages",
+        "streams",
+    ];
+
+    for t in tables {
+        db.execute(Statement::from_string(
+            DbBackend::Postgres,
+            format!("DELETE FROM {}", t),
+        ))
+        .await
+        .unwrap();
+    }
+}
+
+async fn seed_user(db: &DatabaseConnection, user_type: Option<String>) -> Uuid {
+    let id = Uuid::new_v4();
+    let email = match user_type {
+        Some(t) => format!("{}+{}@test.com", t, id),
+        None => format!("{}+{}@test.com", "user_any", id),
+    };
+
+    users::ActiveModel {
+        id: Set(id),
+        email: Set(Some(email)),
+        password_hash: Set(Some("x".into())),
+        auth0_sub: Set(None),
+        created_at: Set(chrono::Utc::now().into()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+async fn seed_employee_record(db: &DatabaseConnection) -> Uuid {
+    let user_id = seed_user(db, Some("employee_rec".to_string())).await;
+    let id = Uuid::new_v4();
+
+    employees::ActiveModel {
+        id: Set(id),
+        user_id: Set(user_id),
+        full_name: Set("Test Employee".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+async fn seed_office_record(db: &DatabaseConnection) -> Uuid {
+    let id = Uuid::new_v4();
+
+    offices::ActiveModel {
+        id: Set(id),
+        name: Set("Test Office".into()),
+        city: Set("Test City".into()),
+        address: Set("Test Address".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+async fn admin_actor(db: &DatabaseConnection) -> ActorContext {
+    let user_id = seed_user(db, Some("admin".to_string())).await;
+
+    ActorContext {
+        user_id,
+        sub: "admin".into(),
+        roles: vec![Role::Admin],
+        employee_id: None,
+        allowed_office_ids: vec![],
+    }
+}
+
+async fn employee_actor(db: &DatabaseConnection) -> ActorContext {
+    let user_id = seed_user(db, Some("employee".to_string())).await;
+    let employee_id = Uuid::new_v4();
+
+    employees::ActiveModel {
+        id: Set(employee_id),
+        user_id: Set(user_id),
+        full_name: Set("Employee Actor".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    ActorContext {
+        user_id,
+        sub: "employee".into(),
+        roles: vec![Role::Employee],
+        employee_id: Some(employee_id),
+        allowed_office_ids: vec![],
+    }
+}
+
+async fn no_role_actor(db: &DatabaseConnection) -> ActorContext {
+    let user_id = seed_user(db, None).await;
+
+    ActorContext {
+        user_id,
+        sub: "".into(),
+        roles: vec![],
+        employee_id: None,
+        allowed_office_ids: vec![],
+    }
+}
+
+/* ----------------------------- */
+/* Assign Office to Employee     */
+/* ----------------------------- */
+
+#[tokio::test]
+async fn admin_can_assign_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    assign_office(
+        &db,
+        &admin,
+        AssignOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap();
+
+    let offices = list_employee_offices(&db, &admin, employee_id)
+        .await
+        .unwrap();
+    assert_eq!(offices.len(), 1);
+    assert_eq!(offices[0], office_id);
+}
+
+#[tokio::test]
+async fn employee_cannot_assign_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    let result = assign_office(
+        &db,
+        &employee,
+        AssignOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, AssignOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_assign_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    let result = assign_office(
+        &db,
+        &user,
+        AssignOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, AssignOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn assign_to_nonexistent_employee_returns_not_found() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    let result = assign_office(
+        &db,
+        &admin,
+        AssignOffice {
+            employee_id: Uuid::new_v4(),
+            office_id,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, AssignOfficeError::EmployeeNotFound));
+}
+
+#[tokio::test]
+async fn assign_nonexistent_office_returns_not_found() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let result = assign_office(
+        &db,
+        &admin,
+        AssignOffice {
+            employee_id,
+            office_id: Uuid::new_v4(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, AssignOfficeError::OfficeNotFound));
+}
+
+#[tokio::test]
+async fn assign_duplicate_returns_already_assigned() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    assign_office(
+        &db,
+        &admin,
+        AssignOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Second assign should return AlreadyAssigned
+    let result = assign_office(
+        &db,
+        &admin,
+        AssignOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, AssignOfficeError::AlreadyAssigned));
+
+    let offices = list_employee_offices(&db, &admin, employee_id)
+        .await
+        .unwrap();
+    assert_eq!(offices.len(), 1);
+}
+
+/* ---------------------------------- */
+/* Remove Office from Employee        */
+/* ---------------------------------- */
+
+#[tokio::test]
+async fn admin_can_remove_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    assign_office(
+        &db,
+        &admin,
+        AssignOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap();
+
+    remove_office(
+        &db,
+        &admin,
+        RemoveOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap();
+
+    let offices = list_employee_offices(&db, &admin, employee_id)
+        .await
+        .unwrap();
+    assert!(offices.is_empty());
+}
+
+#[tokio::test]
+async fn employee_cannot_remove_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    let result = remove_office(
+        &db,
+        &employee,
+        RemoveOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, RemoveOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_remove_office() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    let result = remove_office(
+        &db,
+        &user,
+        RemoveOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, RemoveOfficeError::Forbidden));
+}
+
+#[tokio::test]
+async fn remove_from_nonexistent_employee_returns_not_found() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    let result = remove_office(
+        &db,
+        &admin,
+        RemoveOffice {
+            employee_id: Uuid::new_v4(),
+            office_id,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, RemoveOfficeError::EmployeeNotFound));
+}
+
+#[tokio::test]
+async fn remove_nonexistent_office_returns_not_found() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let result = remove_office(
+        &db,
+        &admin,
+        RemoveOffice {
+            employee_id,
+            office_id: Uuid::new_v4(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(result, RemoveOfficeError::OfficeNotFound));
+}
+
+#[tokio::test]
+async fn remove_missing_assignment_is_noop() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office_record(&db).await;
+
+    // Remove without prior assign — should not error (idempotent)
+    remove_office(
+        &db,
+        &admin,
+        RemoveOffice {
+            employee_id,
+            office_id,
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/* ----------------------------------- */
+/* List Employee Offices               */
+/* ----------------------------------- */
+
+#[tokio::test]
+async fn admin_can_list_offices() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id_1 = seed_office_record(&db).await;
+    let office_id_2 = seed_office_record(&db).await;
+
+    assign_office(
+        &db,
+        &admin,
+        AssignOffice {
+            employee_id,
+            office_id: office_id_1,
+        },
+    )
+    .await
+    .unwrap();
+
+    assign_office(
+        &db,
+        &admin,
+        AssignOffice {
+            employee_id,
+            office_id: office_id_2,
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut offices = list_employee_offices(&db, &admin, employee_id)
+        .await
+        .unwrap();
+    offices.sort();
+
+    let mut expected = vec![office_id_1, office_id_2];
+    expected.sort();
+
+    assert_eq!(offices, expected);
+}
+
+#[tokio::test]
+async fn employee_cannot_list_offices() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let employee = employee_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let result = list_employee_offices(&db, &employee, employee_id)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, ListEmployeeOfficesError::Forbidden));
+}
+
+#[tokio::test]
+async fn no_role_cannot_list_offices() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let user = no_role_actor(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let result = list_employee_offices(&db, &user, employee_id)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, ListEmployeeOfficesError::Forbidden));
+}
+
+#[tokio::test]
+async fn list_for_nonexistent_employee_returns_not_found() {
+    let db = test_db().await;
+    cleanup(&db).await;
+
+    let admin = admin_actor(&db).await;
+
+    let result = list_employee_offices(&db, &admin, Uuid::new_v4())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(result, ListEmployeeOfficesError::EmployeeNotFound));
+}

--- a/logipack-core/crates/core-data/src/repository/employee_offices_repo.rs
+++ b/logipack-core/crates/core-data/src/repository/employee_offices_repo.rs
@@ -1,0 +1,123 @@
+use sea_orm::ActiveValue::Set;
+use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::entity::{employee_offices, employees, offices};
+
+#[derive(Debug, Error)]
+pub enum EmployeeOfficeError {
+    #[error("db error: {0}")]
+    DbError(#[from] DbErr),
+    #[error("employee not found")]
+    EmployeeNotFound,
+    #[error("office not found")]
+    OfficeNotFound,
+}
+
+pub struct EmployeeOfficesRepo;
+
+impl EmployeeOfficesRepo {
+    /// Checks if an employee exists and is not soft-deleted
+    pub async fn employee_exists(
+        db: &DatabaseConnection,
+        employee_id: Uuid,
+    ) -> Result<bool, EmployeeOfficeError> {
+        let result = employees::Entity::find_by_id(employee_id)
+            .filter(employees::Column::DeletedAt.is_null())
+            .one(db)
+            .await?;
+
+        Ok(result.is_some())
+    }
+
+    /// Checks if an office exists and is not soft-deleted
+    pub async fn office_exists(
+        db: &DatabaseConnection,
+        office_id: Uuid,
+    ) -> Result<bool, EmployeeOfficeError> {
+        let result = offices::Entity::find_by_id(office_id)
+            .filter(offices::Column::DeletedAt.is_null())
+            .one(db)
+            .await?;
+
+        Ok(result.is_some())
+    }
+
+    /// Assigns an office to an employee. Returns true if a new row was inserted,
+    /// false if the relation already existed (idempotent).
+    pub async fn assign_office(
+        db: &DatabaseConnection,
+        employee_id: Uuid,
+        office_id: Uuid,
+    ) -> Result<bool, EmployeeOfficeError> {
+        if !Self::employee_exists(db, employee_id).await? {
+            return Err(EmployeeOfficeError::EmployeeNotFound);
+        }
+
+        if !Self::office_exists(db, office_id).await? {
+            return Err(EmployeeOfficeError::OfficeNotFound);
+        }
+
+        // Check if relation already exists
+        let existing = employee_offices::Entity::find()
+            .filter(employee_offices::Column::EmployeeId.eq(employee_id))
+            .filter(employee_offices::Column::OfficeId.eq(office_id))
+            .one(db)
+            .await?;
+
+        if existing.is_some() {
+            return Ok(false);
+        }
+
+        let model = employee_offices::ActiveModel {
+            employee_id: Set(employee_id),
+            office_id: Set(office_id),
+        };
+
+        model.insert(db).await?;
+        Ok(true)
+    }
+
+    /// Removes an office assignment from an employee. No-op if the relation
+    /// does not exist (idempotent).
+    pub async fn remove_office(
+        db: &DatabaseConnection,
+        employee_id: Uuid,
+        office_id: Uuid,
+    ) -> Result<(), EmployeeOfficeError> {
+        if !Self::employee_exists(db, employee_id).await? {
+            return Err(EmployeeOfficeError::EmployeeNotFound);
+        }
+
+        if !Self::office_exists(db, office_id).await? {
+            return Err(EmployeeOfficeError::OfficeNotFound);
+        }
+
+        employee_offices::Entity::delete_many()
+            .filter(employee_offices::Column::EmployeeId.eq(employee_id))
+            .filter(employee_offices::Column::OfficeId.eq(office_id))
+            .exec(db)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Lists all office IDs assigned to an employee.
+    pub async fn list_offices(
+        db: &DatabaseConnection,
+        employee_id: Uuid,
+    ) -> Result<Vec<Uuid>, EmployeeOfficeError> {
+        if !Self::employee_exists(db, employee_id).await? {
+            return Err(EmployeeOfficeError::EmployeeNotFound);
+        }
+
+        let rows = employee_offices::Entity::find()
+            .filter(employee_offices::Column::EmployeeId.eq(employee_id))
+            .all(db)
+            .await?;
+
+        let office_ids = rows.into_iter().map(|r| r.office_id).collect();
+        Ok(office_ids)
+    }
+}

--- a/logipack-core/crates/core-data/src/repository/mod.rs
+++ b/logipack-core/crates/core-data/src/repository/mod.rs
@@ -1,4 +1,5 @@
 pub mod clients_repo;
+pub mod employee_offices_repo;
 pub mod employees_repo;
 pub mod offices_repo;
 pub mod shipments_repo;

--- a/logipack-core/crates/core-data/tests/employee_offices_repo.rs
+++ b/logipack-core/crates/core-data/tests/employee_offices_repo.rs
@@ -1,0 +1,352 @@
+use sea_orm::{ActiveModelTrait, ConnectionTrait, DatabaseConnection, DbBackend, Set, Statement};
+use uuid::Uuid;
+
+use core_data::entity::{employees, offices, users};
+use core_data::repository::employee_offices_repo::{EmployeeOfficeError, EmployeeOfficesRepo};
+use test_infra::test_db;
+
+pub async fn seed_user(db: &DatabaseConnection) -> Uuid {
+    let id = Uuid::new_v4();
+
+    users::ActiveModel {
+        id: Set(id),
+        email: Set(Some(format!("user+{id}@test.com"))),
+        password_hash: Set(Some("x".into())),
+        auth0_sub: Set(None),
+        created_at: Set(chrono::Utc::now().into()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+pub async fn seed_employee(db: &DatabaseConnection) -> Uuid {
+    let user_id = seed_user(db).await;
+    let id = Uuid::new_v4();
+
+    employees::ActiveModel {
+        id: Set(id),
+        user_id: Set(user_id),
+        full_name: Set("Test Employee".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+pub async fn seed_office(db: &DatabaseConnection) -> Uuid {
+    let id = Uuid::new_v4();
+
+    offices::ActiveModel {
+        id: Set(id),
+        name: Set("Test Office".into()),
+        city: Set("Test City".into()),
+        address: Set("Test Address".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(None),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+pub async fn seed_soft_deleted_employee(db: &DatabaseConnection) -> Uuid {
+    let user_id = seed_user(db).await;
+    let id = Uuid::new_v4();
+
+    employees::ActiveModel {
+        id: Set(id),
+        user_id: Set(user_id),
+        full_name: Set("Deleted Employee".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(Some(chrono::Utc::now().into())),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+pub async fn seed_soft_deleted_office(db: &DatabaseConnection) -> Uuid {
+    let id = Uuid::new_v4();
+
+    offices::ActiveModel {
+        id: Set(id),
+        name: Set("Deleted Office".into()),
+        city: Set("Test City".into()),
+        address: Set("Test Address".into()),
+        created_at: Set(chrono::Utc::now().into()),
+        updated_at: Set(chrono::Utc::now().into()),
+        deleted_at: Set(Some(chrono::Utc::now().into())),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    id
+}
+
+pub async fn cleanup_core_data(db: &DatabaseConnection) {
+    let tables = [
+        "shipment_status_history",
+        "shipments",
+        "employee_offices",
+        "employees",
+        "user_roles",
+        "users",
+        "clients",
+        "roles",
+        "offices",
+    ];
+
+    for t in tables {
+        db.execute(Statement::from_string(
+            DbBackend::Postgres,
+            format!("DELETE FROM {}", t),
+        ))
+        .await
+        .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn assign_creates_row() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_employee(&db).await;
+    let office_id = seed_office(&db).await;
+
+    let result = EmployeeOfficesRepo::assign_office(&db, employee_id, office_id)
+        .await
+        .unwrap();
+
+    assert!(result); // true = new row inserted
+
+    let offices = EmployeeOfficesRepo::list_offices(&db, employee_id)
+        .await
+        .unwrap();
+    assert_eq!(offices.len(), 1);
+    assert_eq!(offices[0], office_id);
+}
+
+#[tokio::test]
+async fn assign_duplicate_is_idempotent() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_employee(&db).await;
+    let office_id = seed_office(&db).await;
+
+    let first = EmployeeOfficesRepo::assign_office(&db, employee_id, office_id)
+        .await
+        .unwrap();
+    assert!(first);
+
+    let second = EmployeeOfficesRepo::assign_office(&db, employee_id, office_id)
+        .await
+        .unwrap();
+    assert!(!second); // false = already existed
+
+    let offices = EmployeeOfficesRepo::list_offices(&db, employee_id)
+        .await
+        .unwrap();
+    assert_eq!(offices.len(), 1);
+}
+
+#[tokio::test]
+async fn remove_deletes_row() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_employee(&db).await;
+    let office_id = seed_office(&db).await;
+
+    EmployeeOfficesRepo::assign_office(&db, employee_id, office_id)
+        .await
+        .unwrap();
+
+    EmployeeOfficesRepo::remove_office(&db, employee_id, office_id)
+        .await
+        .unwrap();
+
+    let offices = EmployeeOfficesRepo::list_offices(&db, employee_id)
+        .await
+        .unwrap();
+    assert!(offices.is_empty());
+}
+
+#[tokio::test]
+async fn remove_missing_is_noop() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_employee(&db).await;
+    let office_id = seed_office(&db).await;
+
+    // Remove without prior assign — should not error
+    EmployeeOfficesRepo::remove_office(&db, employee_id, office_id)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn list_returns_correct_office_ids() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_employee(&db).await;
+    let office_id_1 = seed_office(&db).await;
+    let office_id_2 = seed_office(&db).await;
+    let office_id_3 = seed_office(&db).await;
+
+    EmployeeOfficesRepo::assign_office(&db, employee_id, office_id_1)
+        .await
+        .unwrap();
+    EmployeeOfficesRepo::assign_office(&db, employee_id, office_id_2)
+        .await
+        .unwrap();
+    EmployeeOfficesRepo::assign_office(&db, employee_id, office_id_3)
+        .await
+        .unwrap();
+
+    let mut offices = EmployeeOfficesRepo::list_offices(&db, employee_id)
+        .await
+        .unwrap();
+    offices.sort();
+
+    let mut expected = vec![office_id_1, office_id_2, office_id_3];
+    expected.sort();
+
+    assert_eq!(offices, expected);
+}
+
+#[tokio::test]
+async fn employee_not_found_on_assign() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let result = EmployeeOfficesRepo::assign_office(&db, Uuid::new_v4(), office_id)
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::EmployeeNotFound));
+}
+
+#[tokio::test]
+async fn office_not_found_on_assign() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_employee(&db).await;
+
+    let result = EmployeeOfficesRepo::assign_office(&db, employee_id, Uuid::new_v4())
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::OfficeNotFound));
+}
+
+#[tokio::test]
+async fn employee_not_found_on_list() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let result = EmployeeOfficesRepo::list_offices(&db, Uuid::new_v4())
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::EmployeeNotFound));
+}
+
+#[tokio::test]
+async fn employee_not_found_on_remove() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let office_id = seed_office(&db).await;
+
+    let result = EmployeeOfficesRepo::remove_office(&db, Uuid::new_v4(), office_id)
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::EmployeeNotFound));
+}
+
+#[tokio::test]
+async fn soft_deleted_employee_not_found() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_soft_deleted_employee(&db).await;
+    let office_id = seed_office(&db).await;
+
+    // assign
+    let result = EmployeeOfficesRepo::assign_office(&db, employee_id, office_id)
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::EmployeeNotFound));
+
+    // list
+    let result = EmployeeOfficesRepo::list_offices(&db, employee_id)
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::EmployeeNotFound));
+
+    // remove
+    let result = EmployeeOfficesRepo::remove_office(&db, employee_id, office_id)
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::EmployeeNotFound));
+}
+
+#[tokio::test]
+async fn soft_deleted_office_not_found_on_assign() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_employee(&db).await;
+    let office_id = seed_soft_deleted_office(&db).await;
+
+    let result = EmployeeOfficesRepo::assign_office(&db, employee_id, office_id)
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::OfficeNotFound));
+}
+
+#[tokio::test]
+async fn remove_office_returns_office_not_found_when_office_missing() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_employee(&db).await;
+
+    let result = EmployeeOfficesRepo::remove_office(&db, employee_id, Uuid::new_v4())
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::OfficeNotFound));
+}
+
+#[tokio::test]
+async fn remove_office_returns_office_not_found_when_office_soft_deleted() {
+    let db = test_db().await;
+    cleanup_core_data(&db).await;
+
+    let employee_id = seed_employee(&db).await;
+    let office_id = seed_soft_deleted_office(&db).await;
+
+    let result = EmployeeOfficesRepo::remove_office(&db, employee_id, office_id)
+        .await
+        .unwrap_err();
+    assert!(matches!(result, EmployeeOfficeError::OfficeNotFound));
+}

--- a/logipack-hub/hub-api/src/dto/employee_offices.rs
+++ b/logipack-hub/hub-api/src/dto/employee_offices.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AssignOfficeRequest {
+    pub office_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListEmployeeOfficesResponse {
+    pub office_ids: Vec<String>,
+}

--- a/logipack-hub/hub-api/src/dto/mod.rs
+++ b/logipack-hub/hub-api/src/dto/mod.rs
@@ -1,4 +1,5 @@
 pub mod clients;
+pub mod employee_offices;
 pub mod employees;
 pub mod offices;
 pub mod shipments;

--- a/logipack-hub/hub-api/src/error.rs
+++ b/logipack-hub/hub-api/src/error.rs
@@ -50,6 +50,14 @@ impl ApiError {
             message: message.into(),
         }
     }
+
+    pub fn conflict(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code,
+            message: message.into(),
+        }
+    }
 }
 
 impl From<sea_orm::DbErr> for ApiError {

--- a/logipack-hub/hub-api/src/routes/admin_ep/employee_offices.rs
+++ b/logipack-hub/hub-api/src/routes/admin_ep/employee_offices.rs
@@ -1,0 +1,143 @@
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    routing::{delete, get, post},
+};
+use core_application::actor::ActorContext;
+
+use crate::{
+    dto::employee_offices::{AssignOfficeRequest, ListEmployeeOfficesResponse},
+    error::ApiError,
+    policy,
+    state::AppState,
+};
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_employee_offices_handler))
+        .route("/", post(assign_office_handler))
+        .route("/:officeId", delete(remove_office_handler))
+}
+
+async fn assign_office_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Path(employee_id): Path<String>,
+    Json(request): Json<AssignOfficeRequest>,
+) -> Result<axum::http::StatusCode, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let employee_uuid = employee_id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_employee_id", "Employee ID must be a valid UUID")
+    })?;
+
+    let office_uuid = request.office_id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_office_id", "Office ID must be a valid UUID")
+    })?;
+
+    let input = core_application::employee_offices::assign::AssignOffice {
+        employee_id: employee_uuid,
+        office_id: office_uuid,
+    };
+
+    core_application::employee_offices::assign::assign_office(&state.db, &actor, input)
+        .await
+        .map_err(|e| match e {
+            core_application::employee_offices::assign::AssignOfficeError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::employee_offices::assign::AssignOfficeError::EmployeeNotFound => {
+                ApiError::not_found("employee_not_found", "Employee not found")
+            }
+            core_application::employee_offices::assign::AssignOfficeError::OfficeNotFound => {
+                ApiError::not_found("office_not_found", "Office not found")
+            }
+            core_application::employee_offices::assign::AssignOfficeError::AlreadyAssigned => {
+                ApiError::conflict("assignment_exists", "Employee already assigned to office")
+            }
+            core_application::employee_offices::assign::AssignOfficeError::AssignError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    Ok(axum::http::StatusCode::OK)
+}
+
+async fn remove_office_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Path((employee_id, office_id)): Path<(String, String)>,
+) -> Result<axum::http::StatusCode, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let employee_uuid = employee_id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_employee_id", "Employee ID must be a valid UUID")
+    })?;
+
+    let office_uuid = office_id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_office_id", "Office ID must be a valid UUID")
+    })?;
+
+    let input = core_application::employee_offices::remove::RemoveOffice {
+        employee_id: employee_uuid,
+        office_id: office_uuid,
+    };
+
+    core_application::employee_offices::remove::remove_office(&state.db, &actor, input)
+        .await
+        .map_err(|e| match e {
+            core_application::employee_offices::remove::RemoveOfficeError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::employee_offices::remove::RemoveOfficeError::EmployeeNotFound => {
+                ApiError::not_found("employee_not_found", "Employee not found")
+            }
+            core_application::employee_offices::remove::RemoveOfficeError::OfficeNotFound => {
+                ApiError::not_found("office_not_found", "Office not found")
+            }
+            core_application::employee_offices::remove::RemoveOfficeError::RemoveError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
+async fn list_employee_offices_handler(
+    State(state): State<AppState>,
+    actor: ActorContext,
+    Path(employee_id): Path<String>,
+) -> Result<Json<ListEmployeeOfficesResponse>, ApiError> {
+    policy::require_admin(&actor)
+        .map_err(|_| ApiError::forbidden("access_denied", "Access denied"))?;
+
+    let employee_uuid = employee_id.parse::<uuid::Uuid>().map_err(|_| {
+        ApiError::bad_request("invalid_employee_id", "Employee ID must be a valid UUID")
+    })?;
+
+    let office_ids = core_application::employee_offices::list::list_employee_offices(
+        &state.db,
+        &actor,
+        employee_uuid,
+    )
+    .await
+    .map_err(|e| match e {
+        core_application::employee_offices::list::ListEmployeeOfficesError::Forbidden => {
+            ApiError::forbidden("access_denied", "Access denied")
+        }
+        core_application::employee_offices::list::ListEmployeeOfficesError::EmployeeNotFound => {
+            ApiError::not_found("employee_not_found", "Employee not found")
+        }
+        core_application::employee_offices::list::ListEmployeeOfficesError::ListError(err) => {
+            ApiError::internal(err.to_string())
+        }
+    })?;
+
+    let response = ListEmployeeOfficesResponse {
+        office_ids: office_ids.into_iter().map(|id| id.to_string()).collect(),
+    };
+
+    Ok(Json(response))
+}

--- a/logipack-hub/hub-api/src/routes/admin_ep/employees.rs
+++ b/logipack-hub/hub-api/src/routes/admin_ep/employees.rs
@@ -22,6 +22,7 @@ pub fn router() -> Router<AppState> {
         .route("/", post(create_employee_handler))
         .route("/:id", put(update_employee_handler))
         .route("/:id", delete(delete_employee_handler))
+        .nest("/:id/offices", super::employee_offices::router())
 }
 
 async fn list_employees_handler(

--- a/logipack-hub/hub-api/src/routes/admin_ep/mod.rs
+++ b/logipack-hub/hub-api/src/routes/admin_ep/mod.rs
@@ -1,3 +1,4 @@
 pub mod clients;
+pub mod employee_offices;
 pub mod employees;
 pub mod offices;

--- a/logipack-hub/hub-api/tests/employee_offices.rs
+++ b/logipack-hub/hub-api/tests/employee_offices.rs
@@ -1,0 +1,11 @@
+#[path = "helpers.rs"]
+pub mod helpers;
+
+#[path = "employee_offices/employee_offices_assign.rs"]
+mod employee_offices_assign;
+
+#[path = "employee_offices/employee_offices_remove.rs"]
+mod employee_offices_remove;
+
+#[path = "employee_offices/employee_offices_list.rs"]
+mod employee_offices_list;

--- a/logipack-hub/hub-api/tests/employee_offices/employee_offices_assign.rs
+++ b/logipack-hub/hub-api/tests/employee_offices/employee_offices_assign.rs
@@ -1,0 +1,280 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+};
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::helpers::{
+    seed_employee, seed_employee_record, seed_office, setup_app_with_admin, setup_app_with_db,
+};
+
+#[tokio::test]
+async fn admin_can_assign_office_to_employee() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": office_id.to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn assign_same_office_twice_returns_conflict() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office(&db).await;
+
+    // First assign
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": office_id.to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Second assign (conflict)
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": office_id.to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::CONFLICT);
+
+    // Verify only one office in list
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = http_body_util::BodyExt::collect(res.into_body())
+        .await
+        .unwrap()
+        .to_bytes();
+    let body: hub_api::dto::employee_offices::ListEmployeeOfficesResponse =
+        serde_json::from_slice(&body).unwrap();
+    assert_eq!(body.office_ids.len(), 1);
+}
+
+#[tokio::test]
+async fn employee_cannot_assign_office() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": office_id.to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_assign_office() {
+    let (app, db) = setup_app_with_db().await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": office_id.to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn assign_invalid_employee_uuid() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri("/admin/employees/not-a-uuid/offices")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": Uuid::new_v4().to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn assign_invalid_office_id_in_body() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": "not-a-uuid",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn assign_employee_not_found() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", Uuid::new_v4()))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": office_id.to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn assign_office_not_found() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": Uuid::new_v4().to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}

--- a/logipack-hub/hub-api/tests/employee_offices/employee_offices_list.rs
+++ b/logipack-hub/hub-api/tests/employee_offices/employee_offices_list.rs
@@ -1,0 +1,167 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use hub_api::dto::employee_offices::ListEmployeeOfficesResponse;
+
+use crate::helpers::{
+    seed_employee, seed_employee_record, seed_office, setup_app_with_admin, setup_app_with_db,
+};
+
+#[tokio::test]
+async fn admin_can_list_employee_offices() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office(&db).await;
+
+    // Assign first
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": office_id.to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // List
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: ListEmployeeOfficesResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body.office_ids.len(), 1);
+    assert_eq!(body.office_ids[0], office_id.to_string());
+}
+
+#[tokio::test]
+async fn list_empty_offices() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body: ListEmployeeOfficesResponse = serde_json::from_slice(&body).unwrap();
+    assert!(body.office_ids.is_empty());
+}
+
+#[tokio::test]
+async fn employee_cannot_list_offices() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_list_offices() {
+    let (app, db) = setup_app_with_db().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn list_invalid_employee_uuid() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri("/admin/employees/not-a-uuid/offices")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn list_employee_not_found() {
+    let (app, _db, admin) = setup_app_with_admin().await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .uri(format!("/admin/employees/{}/offices", Uuid::new_v4()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}

--- a/logipack-hub/hub-api/tests/employee_offices/employee_offices_remove.rs
+++ b/logipack-hub/hub-api/tests/employee_offices/employee_offices_remove.rs
@@ -1,0 +1,232 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+};
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::helpers::{
+    seed_employee, seed_employee_record, seed_office, setup_app_with_admin, setup_app_with_db,
+};
+
+#[tokio::test]
+async fn admin_can_remove_office_assignment() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office(&db).await;
+
+    // Assign first
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .header("content-type", "application/json")
+                .method(Method::POST)
+                .uri(format!("/admin/employees/{}/offices", employee_id))
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "office_id": office_id.to_string(),
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Remove
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!(
+                    "/admin/employees/{}/offices/{}",
+                    employee_id, office_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn remove_nonexistent_assignment_is_idempotent() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office(&db).await;
+
+    // Remove without prior assign
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!(
+                    "/admin/employees/{}/offices/{}",
+                    employee_id, office_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn employee_cannot_remove_office() {
+    let (app, db) = setup_app_with_db().await;
+    let employee = seed_employee(&db).await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", employee.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!(
+                    "/admin/employees/{}/offices/{}",
+                    employee_id, office_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn no_role_cannot_remove_office() {
+    let (app, db) = setup_app_with_db().await;
+    let employee_id = seed_employee_record(&db).await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", Uuid::new_v4().to_string())
+                .method(Method::DELETE)
+                .uri(format!(
+                    "/admin/employees/{}/offices/{}",
+                    employee_id, office_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn remove_invalid_employee_uuid() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!("/admin/employees/not-a-uuid/offices/{}", office_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn remove_invalid_office_uuid() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!(
+                    "/admin/employees/{}/offices/not-a-uuid",
+                    employee_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn remove_employee_not_found() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let office_id = seed_office(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!(
+                    "/admin/employees/{}/offices/{}",
+                    Uuid::new_v4(),
+                    office_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn remove_office_not_found() {
+    let (app, db, admin) = setup_app_with_admin().await;
+    let employee_id = seed_employee_record(&db).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .header("x-dev-secret", "test_secret")
+                .header("x-dev-user-sub", admin.sub.clone())
+                .method(Method::DELETE)
+                .uri(format!(
+                    "/admin/employees/{}/offices/{}",
+                    employee_id,
+                    Uuid::new_v4()
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
# Admin API – Employee ↔ Offices Assignments

## Objective

Implement admin-only endpoints to manage the relationship between employees and offices (assign, list, remove). This enables controlling which offices an employee is associated with.

Closes #5 

## Endpoints

- `POST /admin/employees/:id/offices` — assign an office to an employee
- `GET  /admin/employees/:id/offices` — list office IDs assigned to an employee
- `DELETE /admin/employees/:id/offices/:officeId` — remove an office assignment

## Requirements

- Admin role required for all endpoints
- UUID parsing/validation for path params and request body
- Proper status codes: `200`, `204`, `400`, `401`, `403`, `404`, `409`
- Idempotent semantics:
  - Assigning the same office twice returns `409 Conflict`
  - Removing a missing assignment is `204 No Content` (no-op)
- Soft-delete aware existence checks:
  - If employee or office is soft-deleted (`deleted_at` set), treat as `not found`
- No public exposure (admin-only)

## Implementation Notes

### core-data
- Add `EmployeeOfficesRepo`:
  - `assign_office(db, employee_id, office_id) -> Result<bool, EmployeeOfficeError>`
    - returns `true` if inserted, `false` if already existed
  - `remove_office(db, employee_id, office_id) -> Result<(), EmployeeOfficeError>` (idempotent)
  - `list_offices(db, employee_id) -> Result<Vec<Uuid>, EmployeeOfficeError>`
- Enforce existence checks using soft-delete filters:
  - employee exists if `employees.deleted_at IS NULL`
  - office exists if `offices.deleted_at IS NULL`

### core-application
- Add `employee_offices` module with use cases:
  - `assign_office` (admin-only, maps repo errors, returns `AlreadyAssigned`)
  - `remove_office` (admin-only, maps repo errors)
  - `list_employee_offices` (admin-only, maps repo errors)

### hub-api
- Add DTOs:
  - `AssignOfficeRequest { office_id: String }`
  - `ListEmployeeOfficesResponse { office_ids: Vec<String> }`
- Add `ApiError::conflict(...)` helper
- Add routes under `admin_ep/employees` via:
  - `.nest("/:id/offices", employee_offices::router())`

## Status Codes / Error Mapping

### Assign (POST)
- `200 OK` — assignment created
- `409 Conflict` — assignment already exists
- `404 Not Found` — employee not found or office not found (including soft-deleted)
- `400 Bad Request` — invalid UUID in path/body
- `401 Unauthorized` — actor missing/unknown (no role)
- `403 Forbidden` — non-admin actor

### List (GET)
- `200 OK` — returns list (can be empty)
- `404 Not Found` — employee not found (including soft-deleted)
- `400 Bad Request` — invalid UUID in path
- `401 Unauthorized` — actor missing/unknown (no role)
- `403 Forbidden` — non-admin actor

### Remove (DELETE)
- `204 No Content` — removed or missing assignment (idempotent)
- `404 Not Found` — employee not found or office not found (including soft-deleted)
- `400 Bad Request` — invalid UUID in path
- `401 Unauthorized` — actor missing/unknown (no role)
- `403 Forbidden` — non-admin actor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added office assignment management for administrators. Administrators can now assign offices to employees, remove office assignments, and view all offices assigned to a specific employee through dedicated admin endpoints. Operations include authorization validation, duplicate prevention with conflict detection, and comprehensive error handling to ensure secure and efficient workspace resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->