### PR TITLE
feat(frontend,auth): implement auth with Auth0 in web client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   rust:
     name: rust (fmt, clippy, test, build)
     runs-on: ubuntu-latest
-    environment: TEST_AUTH0_PRIVATE_PEM
+    environment: Test
 
     services:
       postgres:
@@ -63,6 +63,13 @@ jobs:
     defaults:
       run:
         working-directory: logipack-hub/hub-web
+    env:
+      AUTH0_DOMAIN: example.eu.auth0.com
+      AUTH0_CLIENT_ID: dummy
+      AUTH0_CLIENT_SECRET: dummy
+      AUTH0_CALLBACK_URL: http://localhost:5173/callback
+      AUTH0_LOGOUT_URL: http://localhost:5173/
+      SESSION_SECRET: dummy_dummy_dummy_dummy_dummy_dummy_dummy_dummy
     steps:
       - uses: actions/checkout@v4
 

--- a/logipack-hub/hub-web/bun.lock
+++ b/logipack-hub/hub-web/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "hub-web",
       "dependencies": {
+        "flagpack-core": "^2.1.0",
+        "jose": "^6.1.3",
         "svelte-i18n": "^4.0.1",
       },
       "devDependencies": {
@@ -251,6 +253,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "flagpack-core": ["flagpack-core@2.1.0", "", {}, "sha512-fSld5Hl+AkNKJT78RV1/2Htf8TfN5USYSAOIuBxH2CdGkxY+eC4WrYu19sHyr0CCopeB27+0l+CNu7IUHpChwQ=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "globalyzer": ["globalyzer@0.1.0", "", {}, "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="],
@@ -266,6 +270,8 @@
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 

--- a/logipack-hub/hub-web/package.json
+++ b/logipack-hub/hub-web/package.json
@@ -26,6 +26,7 @@
 	},
 	"dependencies": {
 		"flagpack-core": "^2.1.0",
+		"jose": "^6.1.3",
 		"svelte-i18n": "^4.0.1"
 	}
 }

--- a/logipack-hub/hub-web/src/app.d.ts
+++ b/logipack-hub/hub-web/src/app.d.ts
@@ -6,6 +6,7 @@ declare global {
 		interface Locals {
 			user?: { id: string; email: string } | null;
 			lang?: "en" | "bg";
+			session?: unknown;
 		}
 		// interface PageData {}
 		// interface PageState {}

--- a/logipack-hub/hub-web/src/routes/[lang]/+page.server.ts
+++ b/logipack-hub/hub-web/src/routes/[lang]/+page.server.ts
@@ -1,15 +1,17 @@
 import { redirect } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = async ({ locals, cookies }) => {
-	const authenticated = locals.user ?? cookies.get("lp_session");
+export const load: PageServerLoad = async ({ locals, cookies, params }) => {
+	const authenticated = locals.session ?? cookies.get("lp_session");
+
+	const lang = params.lang ?? "en";
 
 	if (authenticated) {
-		redirect(302, "/app");
+		redirect(302, `/${lang}/app`);
 	}
 
 	return {
 		appName: "LogiPack",
-		loginUrl: "/login",
+		loginUrl: `/${lang}/login`,
 	};
 };

--- a/logipack-hub/hub-web/src/routes/[lang]/+page.svelte
+++ b/logipack-hub/hub-web/src/routes/[lang]/+page.svelte
@@ -175,7 +175,14 @@
 		aria-label="Primary navigation"
 		class="mx-auto flex md:max-w-6xl items-center justify-between rounded-xl border border-white/10 bg-surface-900/80 px-5 py-3 backdrop-blur-md"
 	>
-		<span class="text-lg font-bold text-surface-50">LogiPack</span>
+		<div class="flex items-center gap-3">
+			<img
+				src="https://raw.githubusercontent.com/Emagjby/logipack-assets/refs/heads/main/logipack-crate-green.png"
+				alt="LogiPack Logo"
+				class="h-6 w-6 rounded-sm object-cover"
+			/>
+			<span class="text-lg font-bold text-surface-50">LogiPack</span>
+		</div>
 		<div class="flex items-center gap-3">
 			<!-- Language dropdown -->
 			<div class="relative" data-lang-dropdown>
@@ -241,6 +248,7 @@
 
 			<a
 				href={data.loginUrl}
+				data-sveltekit-reload
 				class="cursor-pointer rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-surface-950 transition-colors duration-200 hover:bg-accent-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950"
 			>
 				{$_("hero.cta_primary")}
@@ -282,6 +290,7 @@
 				<div class="mt-8 flex items-center gap-4">
 					<a
 						href={data.loginUrl}
+						data-sveltekit-reload
 						class="cursor-pointer rounded-lg bg-accent px-6 py-3 font-semibold text-surface-950 transition-colors duration-200 hover:bg-accent-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950"
 					>
 						{$_("hero.cta_primary")}

--- a/logipack-hub/hub-web/src/routes/[lang]/app/+page.svelte
+++ b/logipack-hub/hub-web/src/routes/[lang]/app/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    function logout() {
+        window.location.href = '/logout';
+    }
+</script>
+
+<div class="flex flex-col justify-center items-center h-screen">
+    <h1>Welcome</h1>
+    <p>This is the dashboard page.</p>
+
+    <div class="flex gap-2 mt-4">
+        <button class="px-3 rounded-md py-2 bg-accent hover:bg-accent-hover cursor-pointer text-sm" on:click={logout}>Logout</button>
+    </div>
+</div>

--- a/logipack-hub/hub-web/src/routes/[lang]/layout.css
+++ b/logipack-hub/hub-web/src/routes/[lang]/layout.css
@@ -5,22 +5,22 @@
 @plugin '@tailwindcss/typography';
 
 @theme {
-	--font-sans: "Plus Jakarta Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Plus Jakarta Sans", ui-sans-serif, system-ui, sans-serif;
 
-	--color-surface-950: #020617;
-	--color-surface-900: #0f172a;
-	--color-surface-800: #1e293b;
-	--color-surface-700: #334155;
-	--color-surface-600: #475569;
-	--color-surface-400: #94a3b8;
-	--color-surface-200: #e2e8f0;
-	--color-surface-50: #f8fafc;
+  --color-surface-950: #020617;
+  --color-surface-900: #0f172a;
+  --color-surface-800: #1e293b;
+  --color-surface-700: #334155;
+  --color-surface-600: #475569;
+  --color-surface-400: #94a3b8;
+  --color-surface-200: #e2e8f0;
+  --color-surface-50: #f8fafc;
 
-	--color-accent: #22c55e;
-	--color-accent-hover: #16a34a;
+  --color-accent: #22c55e;
+  --color-accent-hover: #16a34a;
 }
 
 :global(html, body, #app) {
-	min-height: 100vh;
-	background-color: var(--color-surface-950);
+  min-height: 100vh;
+  background-color: var(--color-surface-950);
 }

--- a/logipack-hub/hub-web/src/routes/[lang]/login/+server.ts
+++ b/logipack-hub/hub-web/src/routes/[lang]/login/+server.ts
@@ -1,0 +1,28 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { redirect } from "@sveltejs/kit";
+import {
+	AUTH0_DOMAIN,
+	AUTH0_CLIENT_ID,
+	AUTH0_CALLBACK_URL,
+} from "$env/static/private";
+
+const SUPPORTED = new Set(["en", "bg"]);
+
+export const GET: RequestHandler = async ({ url, cookies }) => {
+	const raw = url.searchParams.get("returnTo") ?? "/app";
+	const returnTo = raw.startsWith("/") && !raw.startsWith("//") ? raw : "/app";
+
+	const cookieLocale = cookies.get("lang");
+	const locale =
+		cookieLocale && SUPPORTED.has(cookieLocale) ? cookieLocale : "en";
+
+	const authorize = new URL(`https://${AUTH0_DOMAIN}/authorize`);
+	authorize.searchParams.set("response_type", "code");
+	authorize.searchParams.set("client_id", AUTH0_CLIENT_ID);
+	authorize.searchParams.set("redirect_uri", AUTH0_CALLBACK_URL);
+	authorize.searchParams.set("ui_locales", locale);
+	authorize.searchParams.set("scope", "openid profile email offline_access");
+	authorize.searchParams.set("state", encodeURIComponent(returnTo));
+
+	throw redirect(302, authorize.toString());
+};

--- a/logipack-hub/hub-web/src/routes/[lang]/register/+server.ts
+++ b/logipack-hub/hub-web/src/routes/[lang]/register/+server.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from "./$types";
+import { redirect } from "@sveltejs/kit";
+import {
+    AUTH0_DOMAIN,
+    AUTH0_CLIENT_ID,
+    AUTH0_CALLBACK_URL,
+} from "$env/static/private";
+
+const SUPPORTED = new Set(["en", "bg"]);
+
+export const GET: RequestHandler = async ({ url, cookies }) => {
+    const raw = url.searchParams.get("returnTo") ?? "/app";
+    const returnTo = raw.startsWith("/") && !raw.startsWith("//") ? raw : "/app";
+
+    const cookieLocale = cookies.get("lang");
+    const locale =
+        cookieLocale && SUPPORTED.has(cookieLocale) ? cookieLocale : "en";
+
+    const authorize = new URL(`https://${AUTH0_DOMAIN}/authorize`);
+    authorize.searchParams.set("response_type", "code");
+    authorize.searchParams.set("client_id", AUTH0_CLIENT_ID);
+    authorize.searchParams.set("redirect_uri", AUTH0_CALLBACK_URL);
+    authorize.searchParams.set("scope", "openid profile email offline_access");
+    authorize.searchParams.set("ui_locales", locale);
+    authorize.searchParams.set("screen_hint", "signup");
+
+    authorize.searchParams.set("state", encodeURIComponent(returnTo));
+
+    throw redirect(302, authorize.toString());
+};

--- a/logipack-hub/hub-web/src/routes/callback/+server.ts
+++ b/logipack-hub/hub-web/src/routes/callback/+server.ts
@@ -1,0 +1,84 @@
+import type { RequestHandler } from "./$types";
+import { redirect, error } from "@sveltejs/kit";
+import {
+	AUTH0_DOMAIN,
+	AUTH0_CLIENT_ID,
+	AUTH0_CLIENT_SECRET,
+	AUTH0_CALLBACK_URL,
+	SESSION_SECRET,
+} from "$env/static/private";
+import { EncryptJWT } from "jose";
+
+function safeRedirectPath(raw: string, fallback = "/app"): string {
+	try {
+		const decoded = decodeURIComponent(raw);
+		if (decoded.startsWith("/") && !decoded.startsWith("//")) return decoded;
+	} catch { }
+	return fallback;
+}
+
+const enc = new TextEncoder();
+
+// Derive a 256-bit (32-byte) key from SESSION_SECRET using Web Crypto API
+async function deriveKey(secret: string): Promise<Uint8Array> {
+	const data = enc.encode(secret);
+	const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+	return new Uint8Array(hashBuffer);
+}
+
+export const GET: RequestHandler = async ({ url, cookies }) => {
+	const code = url.searchParams.get("code");
+	const state = url.searchParams.get("state") ?? "/app";
+	if (!code) throw error(400, "Missing ?code");
+
+	const tokenRes = await fetch(`https://${AUTH0_DOMAIN}/oauth/token`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		signal: AbortSignal.timeout(10000),
+		body: JSON.stringify({
+			grant_type: "authorization_code",
+			client_id: AUTH0_CLIENT_ID,
+			client_secret: AUTH0_CLIENT_SECRET,
+			code,
+			redirect_uri: AUTH0_CALLBACK_URL,
+		}),
+	});
+
+	if (!tokenRes.ok) {
+		const body = await tokenRes.text();
+		console.error("Token exchange failed:", tokenRes.status, body);
+		throw error(502, "Authentication failed, please try again.");
+	}
+
+	const tokens = (await tokenRes.json()) as {
+		access_token: string;
+		id_token?: string;
+		refresh_token?: string;
+		expires_in: number;
+		token_type: string;
+	};
+
+	const expiresAt = Math.floor(Date.now() / 1000) + (tokens.expires_in ?? 3600);
+	const encryptionKey = await deriveKey(SESSION_SECRET);
+
+	const session = await new EncryptJWT({
+		access_token: tokens.access_token,
+		refresh_token: tokens.refresh_token,
+		id_token: tokens.id_token,
+		expires_at: expiresAt,
+	})
+		.setProtectedHeader({ alg: "dir", enc: "A256GCM" })
+		.setIssuedAt()
+		.setExpirationTime("7d")
+		.encrypt(encryptionKey);
+
+	cookies.set("lp_session", session, {
+		path: "/",
+		httpOnly: true,
+		sameSite: "lax",
+		secure: url.protocol === "https:",
+		maxAge: 60 * 60 * 24 * 7,
+	});
+
+	throw redirect(302, safeRedirectPath(state));
+};

--- a/logipack-hub/hub-web/src/routes/logout/+server.ts
+++ b/logipack-hub/hub-web/src/routes/logout/+server.ts
@@ -1,0 +1,17 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { redirect } from "@sveltejs/kit";
+import {
+	AUTH0_DOMAIN,
+	AUTH0_CLIENT_ID,
+	AUTH0_LOGOUT_URL,
+} from "$env/static/private";
+
+export const GET: RequestHandler = async ({ cookies }) => {
+	cookies.delete("lp_session", { path: "/" });
+
+	const u = new URL(`https://${AUTH0_DOMAIN}/v2/logout`);
+	u.searchParams.set("client_id", AUTH0_CLIENT_ID);
+	u.searchParams.set("returnTo", AUTH0_LOGOUT_URL);
+
+	throw redirect(302, u.toString());
+};


### PR DESCRIPTION
## Summary
Adds Auth0 auth flow to hub-web with locale-aware routes and cookie session:
- `/[lang]/login` + `/[lang]/register` redirect to Auth0 (passes `ui_locales`, requests `offline_access`)
- `/callback` exchanges code and sets signed `lp_session` cookie
- `/logout` clears session and redirects via Auth0 logout
- `hooks.server.ts` decodes session + refreshes access token (handles rotation) while keeping existing i18n routing

Closes #15 