### PR TITLE
feat(hub-api): client foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,6 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Test
+        run: bun test

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,7 @@ SHELL := /bin/bash
 
 help:
 	@echo "Targets:"
-	@echo "  test      - cargo test (serialized output with summary)"
-	@echo "  fmt       - cargo fmt --all"
-	@echo "  clippy    - cargo clippy --workspace --all-targets --all-features"
+	@echo "  test      - cargo test (serialized output with summary)" @echo "  fmt       - cargo fmt --all" @echo "  clippy    - cargo clippy --workspace --all-targets --all-features"
 	@echo "  dev-api   - run hub API"
 	@echo "  dev-web   - run SvelteKit dev server"
 	@echo "  build-web - build SvelteKit"
@@ -56,7 +54,7 @@ dev-api:
 	cd logipack-hub/hub-api && cargo run
 
 dev-web:
-	cd logipack-hub/hub-web && bun run dev
+	cd logipack-hub/hub-web && bun run dev --host
 
 build-web:
-	cd logipack-hub/hub-web && bun run build
+	cd logipack-hub/hub-web && bun run build 

--- a/logipack-hub/hub-web/bun.lock
+++ b/logipack-hub/hub-web/bun.lock
@@ -18,6 +18,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.18",
         "@types/node": "^25.2.3",
+        "bun-types": "^1.3.10",
         "svelte": "^5.49.2",
         "svelte-check": "^4.3.6",
         "tailwindcss": "^4.1.18",
@@ -212,6 +213,8 @@
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 

--- a/logipack-hub/hub-web/package.json
+++ b/logipack-hub/hub-web/package.json
@@ -19,6 +19,7 @@
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.1.18",
 		"@types/node": "^25.2.3",
+		"bun-types": "^1.3.10",
 		"svelte": "^5.49.2",
 		"svelte-check": "^4.3.6",
 		"tailwindcss": "^4.1.18",

--- a/logipack-hub/hub-web/src/app.d.ts
+++ b/logipack-hub/hub-web/src/app.d.ts
@@ -1,16 +1,11 @@
-// See https://svelte.dev/docs/kit/types#app.d.ts
-// for information about these interfaces
+import type { LpSession } from "$lib/server/session.server";
+
 declare global {
 	namespace App {
-		// interface Error {}
 		interface Locals {
-			user?: { id: string; email: string } | null;
 			lang?: "en" | "bg";
-			session?: unknown;
+			session: LpSession | null;
 		}
-		// interface PageData {}
-		// interface PageState {}
-		// interface Platform {}
 	}
 }
 

--- a/logipack-hub/hub-web/src/bun.d.ts
+++ b/logipack-hub/hub-web/src/bun.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="bun-types" />
+export { };

--- a/logipack-hub/hub-web/src/lib/server/hubApi/README.md
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/README.md
@@ -1,0 +1,61 @@
+# hubApi Usage Guide
+
+This folder is the only place where `hub-web` should talk to `hub-api`.
+
+## Required pattern
+
+1. In `+page.server.ts` or `+layout.server.ts`, create a client from SSR context.
+2. Call an endpoint with the client.
+3. Map raw DTO data to app-safe data with mapper functions.
+4. Handle `HubApiError` in one place in the route load/action.
+
+Example:
+
+```ts
+import {
+  createHubApiClient,
+  mapOfficeListItemDtoToOfficeListItem,
+} from "$lib/server/hubApi";
+
+export async function load({ fetch, locals }) {
+  const client = createHubApiClient({
+    fetch,
+    locals,
+    baseUrl: process.env.HUB_API_BASE ?? "",
+  });
+
+  try {
+    const res = await client.get<{ offices: unknown[] }>("/admin/offices");
+    const offices = res.data.offices.map((dto) =>
+      mapOfficeListItemDtoToOfficeListItem(dto),
+    );
+    return { offices };
+  } catch (err) {
+    // Route-level mapping of HubApiError to UI state
+    return { offices: [], loadError: true };
+  }
+}
+```
+
+## Forbidden pattern
+
+- Do not call `fetch(${HUB_API_BASE}...)` directly in routes.
+- Do not forward `Cookie` headers to `hub-api`.
+- Do not cast raw JSON in routes with ad hoc `as SomeType`.
+
+## Import rule
+
+Import from the barrel file only:
+
+```ts
+import { createHubApiClient, HubApiError } from "$lib/server/hubApi";
+```
+
+Do not deep import from `dto/*`, `mappers/*`, `errors.ts`, or `httpClient.ts`.
+
+## Reviewer checklist
+
+- Route uses `createHubApiClient` from this module.
+- Route does not call direct `fetch` to `hub-api`.
+- Route maps DTOs through mapper functions.
+- Route handles `HubApiError` explicitly.

--- a/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/auth.test.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/auth.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "bun:test";
+import { getAccessTokenFromLocals } from "../auth";
+
+describe("getAccessTokenFromLocals", () => {
+	test("token returned if exists", () => {
+		const locals = {
+			session: {
+				access_token: "valid_token",
+				expires_at: 123,
+				refresh_token: "refresh_token",
+				role: "",
+				name: "",
+				email: "",
+			},
+		} as any;
+
+		expect(getAccessTokenFromLocals(locals)).toBe("valid_token");
+	});
+
+	test("missing session returns null", () => {
+		const locals = { session: null } as any;
+		expect(getAccessTokenFromLocals(locals)).toBeNull();
+	});
+
+	test("malformed token returns null", () => {
+		const locals = {
+			session: {
+				access_token: 123,
+			},
+		} as any;
+
+		expect(getAccessTokenFromLocals(locals)).toBeNull();
+	});
+
+	test("empty or whitespace token returns null", () => {
+		const locals = {
+			session: {
+				access_token: "   ",
+			},
+		} as any;
+
+		expect(getAccessTokenFromLocals(locals)).toBeNull();
+	});
+});

--- a/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/errors.test.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/errors.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import {
+	HubApiError,
+	hubApiErrorFromResponse,
+	hubApiErrorFromThrowable,
+	parseJsonOrThrowHubApiError,
+} from "../errors";
+
+describe("HubApiError model", () => {
+	test("400 JSON body {code,message}", async () => {
+		const response = new Response(
+			JSON.stringify({ code: "BAD_INPUT", message: "nope" }),
+			{
+				status: 400,
+				headers: { "content-type": "application/json" },
+			},
+		);
+
+		const err = await hubApiErrorFromResponse({
+			response,
+			upstream: { method: "POST", path: "/x" },
+		});
+
+		expect(err).toBeInstanceOf(HubApiError);
+		expect(err.status).toBe(400);
+		expect(err.code).toBe("BAD_INPUT");
+		expect(err.message).toBe("nope");
+		expect(err.retryable).toBe(false);
+	});
+
+	test("403 non-JSON body", async () => {
+		const response = new Response("forbidden", { status: 403 });
+
+		const err = await hubApiErrorFromResponse({
+			response,
+			upstream: { method: "GET", path: "/secure" },
+		});
+
+		expect(err.status).toBe(403);
+		expect(err.retryable).toBe(false);
+		expect(err.code).toBe("UPSTREAM_ERROR_TEXT");
+		expect(err.message).toBe("forbidden");
+	});
+
+	test("404 empty body", async () => {
+		const response = new Response("", { status: 404 });
+
+		const err = await hubApiErrorFromResponse({
+			response,
+			upstream: { method: "GET", path: "/missing" },
+		});
+
+		expect(err.status).toBe(404);
+		expect(err.retryable).toBe(false);
+		expect(err.code).toBe("UPSTREAM_ERROR");
+		expect(err.message).toContain("404");
+	});
+
+	test("500 non-JSON", async () => {
+		const response = new Response("kaboom", { status: 500 });
+
+		const err = await hubApiErrorFromResponse({
+			response,
+			upstream: { method: "GET", path: "/boom" },
+		});
+
+		expect(err.status).toBe(500);
+		expect(err.retryable).toBe(true);
+		expect(err.code).toBe("UPSTREAM_ERROR_TEXT");
+		expect(err.message).toBe("kaboom");
+	});
+
+	test("timeout/abort -> retryable", () => {
+		const abortErr = new DOMException("Aborted", "AbortError");
+
+		const err = hubApiErrorFromThrowable({
+			err: abortErr,
+			upstream: { method: "GET", path: "/slow" },
+		});
+
+		expect(err.status).toBe(0);
+		expect(err.code).toBe("ABORTED");
+		expect(err.retryable).toBe(true);
+	});
+
+	test("JSON parse failure on expected JSON responses", async () => {
+		const response = new Response("not-json", {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		});
+
+		const promise = parseJsonOrThrowHubApiError<{ ok: boolean }>({
+			response,
+			upstream: { method: "GET", path: "/ok" },
+		});
+
+		await expect(promise).rejects.toBeInstanceOf(HubApiError);
+	});
+});

--- a/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/httpClient.test.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/httpClient.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { createHubApiClient } from "../httpClient";
+import { HubApiError } from "../errors";
+
+function makeFetchMock(
+	fn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+) {
+	return fn as unknown as typeof fetch;
+}
+
+describe("createHubApiClient", () => {
+	test("auth header attached when token exists", async () => {
+		const fetchMock = makeFetchMock(async (_url, init) => {
+			expect(init?.headers).toBeTruthy();
+			const headers = init!.headers as Record<string, string>;
+			expect(headers.Authorization).toBe("Bearer tok");
+			return new Response(JSON.stringify({ ok: true }), { status: 200 });
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: {
+				session: {
+					access_token: "tok",
+					refresh_token: "rt",
+					expires_at: 1,
+					role: "",
+					name: "",
+					email: "",
+				},
+			} as any,
+			baseUrl: "https://example.com",
+			timeoutMs: 50_000,
+		});
+
+		const res = await client.get<{ ok: boolean }>("/x");
+		expect(res.ok).toBe(true);
+		expect(res.data.ok).toBe(true);
+	});
+
+	test("auth header omitted when token missing", async () => {
+		const fetchMock = makeFetchMock(async (_url, init) => {
+			const headers = init!.headers as Record<string, string>;
+			expect(headers.Authorization).toBeUndefined();
+			return new Response(JSON.stringify({ ok: true }), { status: 200 });
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: null } as any,
+			baseUrl: "https://example.com",
+		});
+
+		const res = await client.get<{ ok: boolean }>("/x");
+		expect(res.ok).toBe(true);
+	});
+
+	test("body serialization sets content-type and JSON string body", async () => {
+		const fetchMock = makeFetchMock(async (_url, init) => {
+			const headers = init!.headers as Record<string, string>;
+			expect(headers["Content-Type"]).toBe("application/json");
+			expect(init!.body).toBe(JSON.stringify({ a: 1 }));
+			return new Response(JSON.stringify({ ok: true }), { status: 200 });
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: null } as any,
+			baseUrl: "https://example.com",
+		});
+
+		await client.post<{ ok: boolean }>("/x", { a: 1 }, { auth: false });
+	});
+
+	test("no cookie forwarding (explicit cookie header) -> HubApiError", async () => {
+		const fetchMock = makeFetchMock(async () => {
+			throw new Error("should not reach fetch");
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: null } as any,
+			baseUrl: "https://example.com",
+		});
+
+		await expect(
+			client.get("/x", { headers: { Cookie: "lp_session=lol" } }),
+		).rejects.toBeInstanceOf(HubApiError);
+	});
+
+	test("success JSON path", async () => {
+		const fetchMock = makeFetchMock(async () => {
+			return new Response(JSON.stringify({ value: 42 }), { status: 200 });
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: null } as any,
+			baseUrl: "https://example.com",
+		});
+
+		const res = await client.get<{ value: number }>("/x");
+		expect(res.data.value).toBe(42);
+	});
+
+	test("mapped error path (400 JSON {code,message})", async () => {
+		const fetchMock = makeFetchMock(async () => {
+			return new Response(JSON.stringify({ code: "BAD", message: "nope" }), {
+				status: 400,
+			});
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: null } as any,
+			baseUrl: "https://example.com",
+		});
+
+		await expect(client.get("/x")).rejects.toBeInstanceOf(HubApiError);
+
+		try {
+			await client.get("/x");
+			throw new Error("expected to throw");
+		} catch (err: any) {
+			expect(err.name).toBe("HubApiError");
+			expect(err.message).toBe("nope");
+			expect(err.status).toBe(400);
+			expect(err.code).toBe("BAD");
+			expect(err.retryable).toBe(false);
+		}
+	});
+
+	test("raw TypeError should not leak (network error normalized)", async () => {
+		const fetchMock = makeFetchMock(async () => {
+			throw new TypeError("network down");
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: null } as any,
+			baseUrl: "https://example.com",
+		});
+
+		await expect(client.get("/x")).rejects.toBeInstanceOf(HubApiError);
+	});
+
+	test("raw SyntaxError should not leak (JSON parse failure normalized)", async () => {
+		const fetchMock = makeFetchMock(async () => {
+			return new Response("not-json", {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: null } as any,
+			baseUrl: "https://example.com",
+		});
+
+		await expect(client.get("/x")).rejects.toBeInstanceOf(HubApiError);
+	});
+});

--- a/logipack-hub/hub-web/src/lib/server/hubApi/auth.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/auth.ts
@@ -1,0 +1,19 @@
+/**
+ * Extract bearer access token from SSR locals.
+ *
+ * Rules:
+ * - Only reads locals.session.access_token
+ * - Does not inspect cookies/headers/url
+ * - Returns null unless it's a non-empty string
+ */
+export function getAccessTokenFromLocals(locals: App.Locals): string | null {
+	const token = locals.session?.access_token;
+	return validate_access_token(token);
+}
+
+function validate_access_token(token: unknown): string | null {
+	if (typeof token === "string" && token.trim() !== "") {
+		return token;
+	}
+	return null;
+}

--- a/logipack-hub/hub-web/src/lib/server/hubApi/dto/clients.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/dto/clients.ts
@@ -1,0 +1,4 @@
+import type { UnknownDto } from "./common";
+
+export type ClientListItemDto = UnknownDto;
+export type ClientDetailDto = UnknownDto;

--- a/logipack-hub/hub-web/src/lib/server/hubApi/dto/common.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/dto/common.ts
@@ -1,0 +1,2 @@
+// raw DTOs, filled in when ep are wired
+export type UnknownDto = Record<string, unknown>;

--- a/logipack-hub/hub-web/src/lib/server/hubApi/dto/employees.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/dto/employees.ts
@@ -1,0 +1,5 @@
+import type { UnknownDto } from "./common";
+
+export type EmployeeListItemDto = UnknownDto;
+export type EmployeeDetailDto = UnknownDto;
+export type EmployeeOfficeAssignmentDto = UnknownDto;

--- a/logipack-hub/hub-web/src/lib/server/hubApi/dto/identity.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/dto/identity.ts
@@ -1,0 +1,3 @@
+import type { UnknownDto } from "./common";
+
+export type MeDto = UnknownDto;

--- a/logipack-hub/hub-web/src/lib/server/hubApi/dto/offices.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/dto/offices.ts
@@ -1,0 +1,4 @@
+import type { UnknownDto } from "./common";
+
+export type OfficeListItemDto = UnknownDto;
+export type OfficeDetailDto = UnknownDto;

--- a/logipack-hub/hub-web/src/lib/server/hubApi/dto/shipments.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/dto/shipments.ts
@@ -1,0 +1,4 @@
+import type { UnknownDto } from "./common";
+
+export type ShipmentListItemDto = UnknownDto;
+export type ShipmentDetailDto = UnknownDto;

--- a/logipack-hub/hub-web/src/lib/server/hubApi/errors.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/errors.ts
@@ -1,0 +1,210 @@
+import type { HttpMethod } from "./types";
+
+export type HubApiUpstream = {
+	method?: HttpMethod;
+	path?: string;
+};
+
+export type HubApiErrorInit = {
+	status: number;
+	code: string;
+	message: string;
+	retryable: boolean;
+	upstream?: HubApiUpstream;
+	cause?: unknown;
+};
+
+export class HubApiError extends Error {
+	status: number;
+	code: string;
+	retryable: boolean;
+	upstream?: HubApiUpstream;
+	cause?: unknown;
+
+	constructor(init: HubApiErrorInit) {
+		super(init.message);
+		this.name = "HubApiError";
+		Object.setPrototypeOf(this, HubApiError.prototype);
+		this.status = init.status;
+		this.code = init.code;
+		this.retryable = init.retryable;
+		this.upstream = init.upstream;
+		this.cause = init.cause;
+	}
+}
+
+// Helpers:
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+	return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+function retryableByStatus(status: number): boolean {
+	if (status >= 500) return true;
+	return false;
+}
+
+/**
+ * Parse backend error JSON shape `{ code: message }`.
+ * Returns null if body isn't that shape.
+ */
+export function parseBackendErrorJson(
+	body: unknown,
+): { code: string; message: string } | null {
+	if (!isRecord(body)) return null;
+	const code = body.code;
+	const message = body.message;
+
+	if (typeof code !== "string" || !code) return null;
+	if (typeof message !== "string" || !message) return null;
+
+	return { code, message };
+}
+
+/**
+ * Normalize an HTTP error response into HubApiError.
+ * - Attempts JSON parse first.
+ * - Supports backend `{ code, message }`.
+ * - Falls back to body text / generic message.
+ */
+export async function hubApiErrorFromResponse(args: {
+	response: Response;
+	upstream?: HubApiUpstream;
+}): Promise<HubApiError> {
+	const { response, upstream } = args;
+	const status = response.status;
+
+	const forText = response.clone();
+
+	let parsedJson: unknown | null = null;
+	let jsonParseFailed = false;
+
+	try {
+		parsedJson = await response.json();
+	} catch {
+		jsonParseFailed = true;
+	}
+
+	if (parsedJson !== null && !jsonParseFailed) {
+		const backend = parseBackendErrorJson(parsedJson);
+		if (backend) {
+			return new HubApiError({
+				status,
+				code: backend.code,
+				message: backend.message,
+				retryable: retryableByStatus(status),
+				upstream,
+			});
+		}
+
+		return new HubApiError({
+			status,
+			code: "UPSTREAM_ERROR_JSON",
+			message: `upstream returned error status ${status}`,
+			retryable: retryableByStatus(status),
+			upstream,
+			cause: parsedJson,
+		});
+	}
+
+	let bodyText: string | null = null;
+	try {
+		bodyText = await forText.text();
+	} catch {
+		bodyText = null;
+	}
+
+	const hasText = typeof bodyText === "string" && bodyText.trim() !== "";
+
+	return new HubApiError({
+		status,
+		code: hasText ? "UPSTREAM_ERROR_TEXT" : "UPSTREAM_ERROR",
+		message: hasText
+			? bodyText!.trim()
+			: `upstream returned error status ${status}`,
+		retryable: retryableByStatus(status),
+		upstream,
+		cause: jsonParseFailed
+			? new SyntaxError("failed to parse error body as JSON")
+			: undefined,
+	});
+}
+
+/**
+ * Normalize failures that happen before a Response exists:
+ * - Abort / timeout
+ * - Network / fetch TypeError
+ * - Unknown throwables
+ */
+export function hubApiErrorFromThrowable(args: {
+	err: unknown;
+	upstream?: HubApiUpstream;
+}): HubApiError {
+	const { err, upstream } = args;
+
+	if (err instanceof DOMException && err.name === "AbortError") {
+		return new HubApiError({
+			status: 0,
+			code: "ABORTED",
+			message: "request was aborted",
+			retryable: true,
+			upstream,
+			cause: err,
+		});
+	}
+
+	if (err instanceof TypeError) {
+		return new HubApiError({
+			status: 0,
+			code: "NETWORK_ERROR",
+			message: err.message || "network error",
+			retryable: true,
+			upstream,
+			cause: err,
+		});
+	}
+
+	if (err instanceof SyntaxError) {
+		return new HubApiError({
+			status: 0,
+			code: "JSON_PARSE_FAILED",
+			message: err.message || "failed to parse JSON",
+			retryable: false,
+			upstream,
+			cause: err,
+		});
+	}
+
+	return new HubApiError({
+		status: 0,
+		code: "UNKNOWN_ERROR",
+		message: err instanceof Error ? err.message : "unknown error",
+		retryable: true,
+		upstream,
+		cause: err,
+	});
+}
+
+/**
+ * Wrap JSON parsing of a successful response.
+ * If parsing fails, throw a HubApiError describing JSON parse failure.
+ */
+export async function parseJsonOrThrowHubApiError<T>(args: {
+	response: Response;
+	upstream?: HubApiUpstream;
+}): Promise<T> {
+	const { response, upstream } = args;
+
+	try {
+		return (await response.json()) as T;
+	} catch (error) {
+		throw new HubApiError({
+			status: response.status,
+			code: "JSON_PARSE_FAILED",
+			message: "failed to parse response body as JSON",
+			retryable: response.status >= 500,
+			upstream,
+			cause: error instanceof Error ? error : undefined,
+		});
+	}
+}

--- a/logipack-hub/hub-web/src/lib/server/hubApi/httpClient.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/httpClient.ts
@@ -1,0 +1,135 @@
+import type { HttpMethod, HubApiRequestOptions, HubApiSuccess } from "./types";
+import { getAccessTokenFromLocals } from "./auth";
+import {
+	HubApiError,
+	hubApiErrorFromResponse,
+	hubApiErrorFromThrowable,
+	parseJsonOrThrowHubApiError,
+} from "./errors";
+
+type CreateHubApiClientArgs = {
+	fetch: typeof globalThis.fetch;
+	locals: App.Locals;
+	baseUrl: string;
+	timeoutMs?: number;
+};
+
+type RequestArgs = Omit<HubApiRequestOptions, "baseUrl"> & {
+	/**
+	 * If provided, overrides client timeoutMs
+	 */
+	timeoutMs?: number;
+};
+
+function joinUrl(baseUrl: string, path: string): string {
+	const base = baseUrl.replace(/\/+$/, "");
+	const p = path.startsWith("/") ? path : `/${path}`;
+	return `${base}${p}`;
+}
+
+function hasOwnCookieHeader(headers?: Record<string, string>): boolean {
+	if (!headers) return false;
+	return Object.keys(headers).some((k) => k.toLowerCase() === "cookie");
+}
+
+export function createHubApiClient(args: CreateHubApiClientArgs) {
+	const { fetch, locals, baseUrl } = args;
+	const defaultTimeoutMs = args.timeoutMs ?? 10_000;
+
+	async function request<T>(req: RequestArgs): Promise<HubApiSuccess<T>> {
+		const method: HttpMethod = req.method;
+		const url = joinUrl(baseUrl, req.path);
+
+		if (hasOwnCookieHeader(req.headers)) {
+			throw new HubApiError({
+				status: 0,
+				code: "COOKIE_FORWARDING_FORBIDDEN",
+				message: "cookie header forwarding to hub-api is forbidden",
+				retryable: false,
+				upstream: { method, path: req.path },
+			});
+		}
+
+		const upstream = { method, path: req.path };
+
+		const controller = new AbortController();
+		const timeoutMs = req.timeoutMs ?? defaultTimeoutMs;
+		const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+		const headers: Record<string, string> = {
+			Accept: "application/json",
+			...(req.headers ?? {}),
+		};
+
+		const wantsAuth = req.auth !== false;
+		if (wantsAuth) {
+			const token = getAccessTokenFromLocals(locals);
+			if (token) headers.Authorization = `Bearer ${token}`;
+		}
+
+		let body: string | undefined;
+		if (req.body !== undefined) {
+			headers["Content-Type"] = "application/json";
+			try {
+				body = JSON.stringify(req.body);
+			} catch (err) {
+				clearTimeout(timeout);
+				throw new HubApiError({
+					status: 0,
+					code: "JSON_SERIALIZE_FAILED",
+					message: "failed to serialize request body as JSON",
+					retryable: false,
+					upstream,
+					cause: err,
+				});
+			}
+		}
+
+		try {
+			const res = await fetch(url, {
+				method,
+				headers,
+				body,
+				signal: controller.signal,
+			});
+
+			if (!res.ok) {
+				throw await hubApiErrorFromResponse({ response: res, upstream });
+			}
+
+			const data = await parseJsonOrThrowHubApiError<T>({
+				response: res,
+				upstream,
+			});
+
+			return { ok: true, status: res.status, data };
+		} catch (err) {
+			if (err instanceof HubApiError) throw err;
+
+			throw hubApiErrorFromThrowable({ err, upstream });
+		} finally {
+			clearTimeout(timeout);
+		}
+	}
+
+	return {
+		request,
+		get: <T>(path: string, opts?: Omit<RequestArgs, "method" | "path">) =>
+			request<T>({ method: "GET", path, ...(opts ?? {}) }),
+
+		post: <T>(
+			path: string,
+			body?: unknown,
+			opts?: Omit<RequestArgs, "method" | "path" | "body">,
+		) => request<T>({ method: "POST", path, body, ...(opts ?? {}) }),
+
+		put: <T>(
+			path: string,
+			body?: unknown,
+			opts?: Omit<RequestArgs, "method" | "path" | "body">,
+		) => request<T>({ method: "PUT", path, body, ...(opts ?? {}) }),
+
+		delete: <T>(path: string, opts?: Omit<RequestArgs, "method" | "path">) =>
+			request<T>({ method: "DELETE", path, ...(opts ?? {}) }),
+	};
+}

--- a/logipack-hub/hub-web/src/lib/server/hubApi/index.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/index.ts
@@ -1,0 +1,30 @@
+export type {
+  HttpMethod,
+  HubApiRequestOptions,
+  HubApiSuccess,
+  HubApiFailure,
+} from "./types";
+
+export { getAccessTokenFromLocals } from "./auth";
+export {
+  HubApiError,
+  hubApiErrorFromResponse,
+  hubApiErrorFromThrowable,
+  parseJsonOrThrowHubApiError,
+} from "./errors";
+
+export { createHubApiClient } from "./httpClient";
+export * from "./normalizers";
+
+export * from "./dto/common";
+export * from "./dto/offices";
+export * from "./dto/clients";
+export * from "./dto/employees";
+export * from "./dto/shipments";
+export * from "./dto/identity";
+
+export * from "./mappers/offices";
+export * from "./mappers/clients";
+export * from "./mappers/employees";
+export * from "./mappers/shipments";
+export * from "./mappers/identity";

--- a/logipack-hub/hub-web/src/lib/server/hubApi/mappers/clients.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/mappers/clients.ts
@@ -1,0 +1,16 @@
+import type { ClientListItemDto, ClientDetailDto } from "../dto/clients";
+
+export type ClientListItem = Record<string, never>;
+export type ClientDetail = Record<string, never>;
+
+export function mapClientListItemDtoToClientListItem(
+	_dto: ClientListItemDto,
+): ClientListItem {
+	return {};
+}
+
+export function mapClientDetailDtoToClientDetail(
+	_dto: ClientDetailDto,
+): ClientDetail {
+	return {};
+}

--- a/logipack-hub/hub-web/src/lib/server/hubApi/mappers/employees.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/mappers/employees.ts
@@ -1,0 +1,27 @@
+import type {
+	EmployeeListItemDto,
+	EmployeeDetailDto,
+	EmployeeOfficeAssignmentDto,
+} from "../dto/employees";
+
+export type EmployeeListItem = Record<string, never>;
+export type EmployeeDetail = Record<string, never>;
+export type EmployeeOfficeAssignment = Record<string, never>;
+
+export function mapEmployeeListItemDtoToEmployeeListItem(
+	_dto: EmployeeListItemDto,
+): EmployeeListItem {
+	return {};
+}
+
+export function mapEmployeeDetailDtoToEmployeeDetail(
+	_dto: EmployeeDetailDto,
+): EmployeeDetail {
+	return {};
+}
+
+export function mapEmployeeOfficeAssignmentDtoToEmployeeOfficeAssignment(
+	_dto: EmployeeOfficeAssignmentDto,
+): EmployeeOfficeAssignment {
+	return {};
+}

--- a/logipack-hub/hub-web/src/lib/server/hubApi/mappers/identity.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/mappers/identity.ts
@@ -1,0 +1,7 @@
+import type { MeDto } from "../dto/identity";
+
+export type Me = Record<string, never>;
+
+export function mapMeDtoToMe(_dto: MeDto): Me {
+	return {};
+}

--- a/logipack-hub/hub-web/src/lib/server/hubApi/mappers/offices.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/mappers/offices.ts
@@ -1,0 +1,16 @@
+import type { OfficeListItemDto, OfficeDetailDto } from "../dto/offices";
+
+export type OfficeListItem = Record<string, never>;
+export type OfficeDetail = Record<string, never>;
+
+export function mapOfficeListItemDtoToOfficeListItem(
+	_dto: OfficeListItemDto,
+): OfficeListItem {
+	return {};
+}
+
+export function mapOfficeDetailDtoToOfficeDetail(
+	_dto: OfficeDetailDto,
+): OfficeDetail {
+	return {};
+}

--- a/logipack-hub/hub-web/src/lib/server/hubApi/mappers/shipments.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/mappers/shipments.ts
@@ -1,0 +1,16 @@
+import type { ShipmentListItemDto, ShipmentDetailDto } from "../dto/shipments";
+
+export type ShipmentListItem = Record<string, never>;
+export type ShipmentDetail = Record<string, never>;
+
+export function mapShipmentListItemDtoToShipmentListItem(
+	_dto: ShipmentListItemDto,
+): ShipmentListItem {
+	return {};
+}
+
+export function mapShipmentDetailDtoToShipmentDetail(
+	_dto: ShipmentDetailDto,
+): ShipmentDetail {
+	return {};
+}

--- a/logipack-hub/hub-web/src/lib/server/hubApi/normalizers.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/normalizers.ts
@@ -1,0 +1,42 @@
+export class HubApiMappingError extends Error {
+	endpoint: string;
+	field: string;
+	cause?: unknown;
+
+	constructor(args: {
+		endpoint: string;
+		field: string;
+		message: string;
+		cause?: unknown;
+	}) {
+		super(args.message);
+		this.name = "HubApiMappingError";
+		this.endpoint = args.endpoint;
+		this.field = args.field;
+		this.cause = args.cause;
+	}
+}
+
+export function requireIsoDateTime(_args: {
+	endpoint: string;
+	field: string;
+	value: unknown;
+}): string {
+	throw new HubApiMappingError({
+		endpoint: _args.endpoint,
+		field: _args.field,
+		message: "requireIsoDateTime not implemented",
+	});
+}
+
+export function cleanNullablestring(_v: unknown): string | null {
+	return null;
+}
+
+export function normalizeShipmentStatusStrict(_args: {
+	endpoint: string;
+	field: string;
+	value: unknown;
+}): "unknown" | string {
+	return "unknown";
+}

--- a/logipack-hub/hub-web/src/lib/server/hubApi/types.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/types.ts
@@ -1,0 +1,57 @@
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+
+export type HubApiRequestOptions = {
+	method: HttpMethod;
+	path: string;
+
+	/**
+	 * Absolute base URL for hub-api
+	 * The client will join baseUrl + path.
+	 */
+	baseUrl?: string;
+
+	/**
+	 * Request timeout in ms.
+	 * HTTP client will enforce via AbortController.
+	 */
+	timeoutMs?: number;
+
+	/**
+	 * JSON-serializable request body.
+	 * Client will set Content-Type and JSON.stringify auto.
+	 */
+	body?: unknown;
+
+	/**
+	 * Extra headers to send with the request.
+	 */
+	headers?: Record<string, string>;
+
+	/**
+	 * Override whether this request should include bearer auth.
+	 * Default to true, and client will include bearer token if available.
+	 */
+	auth?: boolean;
+};
+
+export type HubApiSuccess<T> = {
+	ok: true;
+	status: number;
+	data: T;
+};
+
+export type HubApiFailure = {
+	ok: false;
+	status: number;
+	code: string;
+	message: string;
+	retryable: boolean;
+	/**
+	 * Optional upstream context, used for debugging.
+	 * Keep this minimal and avoid leaking secrets.
+	 */
+	upstream?: {
+		method?: HttpMethod;
+		path?: string;
+	};
+};

--- a/logipack-hub/hub-web/src/lib/server/session.server.ts
+++ b/logipack-hub/hub-web/src/lib/server/session.server.ts
@@ -1,38 +1,71 @@
 export type LpSession = {
 	access_token: string;
-	refresh_token?: string;
-	id_token?: string;
 	expires_at: number;
-	role: string; // normalize to "" if missing
-	name: string; // normalize to "" if missing
-	email: string; // normalize to "" if missing
+	role: string;
+	name: string;
+	email: string;
+
+	refresh_token: string;
+	id_token?: string;
+
+	[key: string]: unknown;
 };
 
 function isObject(v: unknown): v is Record<string, unknown> {
 	return !!v && typeof v === "object";
 }
 
+function fail(field: string, expected: string, received: unknown): null {
+	console.error(`[parseSession] invalid ${field} (expected ${expected})`, {
+		received,
+	});
+	return null;
+}
+
 export function parseSession(payload: unknown): LpSession | null {
-	if (!isObject(payload)) return null;
+	if (!isObject(payload)) {
+		console.error("[parseSession] invalid payload (expected object)", {
+			received: payload,
+		});
+		return null;
+	}
 
 	const access_token = payload.access_token;
+	// TODO
+	// const refresh_token = payload.refresh_token;
 	const expires_at = payload.expires_at;
+	const role = payload.role;
+	const name = payload.name;
+	const email = payload.email;
+	const id_token = payload.id_token;
 
-	if (typeof access_token !== "string" || !access_token) return null;
+	if (typeof access_token !== "string" || !access_token)
+		return fail("access_token", "non-empty string", access_token);
+
+	// TODO
+	// if (typeof refresh_token !== "string" || !refresh_token)
+	// 	return fail("refresh_token", "non-empty string", refresh_token);
+
 	if (typeof expires_at !== "number" || !Number.isFinite(expires_at))
-		return null;
+		return fail("expires_at", "finite number", expires_at);
+
+	if (typeof role !== "string") return fail("role", "string", role);
+
+	if (typeof name !== "string") return fail("name", "string", name);
+
+	if (typeof email !== "string") return fail("email", "string", email);
+
+	if (id_token !== undefined && typeof id_token !== "string")
+		return fail("id_token", "string | undefined", id_token);
 
 	return {
 		access_token,
-		refresh_token:
-			typeof payload.refresh_token === "string"
-				? payload.refresh_token
-				: undefined,
-		id_token:
-			typeof payload.id_token === "string" ? payload.id_token : undefined,
 		expires_at,
-		role: typeof payload.role === "string" ? payload.role : "",
-		name: typeof payload.name === "string" ? payload.name : "",
-		email: typeof payload.email === "string" ? payload.email : "",
+		role,
+		name,
+		email,
+		// TODO: FIX THIS POST MVP
+		refresh_token: "",
+		id_token,
 	};
 }

--- a/logipack-hub/hub-web/src/routes/+page.server.ts
+++ b/logipack-hub/hub-web/src/routes/+page.server.ts
@@ -1,52 +1,56 @@
-import { redirect } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
+import { redirect } from "@sveltejs/kit";
+import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals, cookies }) => {
-	// Check locals.user first (set by hooks.server.ts when auth is wired up)
-	// Fall back to lp_session cookie as a placeholder mechanism
-	const authenticated = locals.user ?? cookies.get('lp_session');
+	const authenticated = locals.session ?? cookies.get("lp_session");
 
 	if (authenticated) {
-		redirect(302, '/app');
+		redirect(302, "/app");
 	}
 
 	return {
-		appName: 'LogiPack',
-		loginUrl: '/login',
+		appName: "LogiPack",
+		loginUrl: "/login",
 		features: [
 			{
-				title: 'Shipment timeline',
-				description: 'Chronological audit of every event — who changed what, when.',
-				icon: 'timeline'
+				title: "Shipment timeline",
+				description:
+					"Chronological audit of every event — who changed what, when.",
+				icon: "timeline",
 			},
 			{
-				title: 'Office-aware tracking',
-				description: 'See the current office, track handoffs between locations.',
-				icon: 'office'
+				title: "Office-aware tracking",
+				description:
+					"See the current office, track handoffs between locations.",
+				icon: "office",
 			},
 			{
-				title: 'Role-based consoles',
-				description: 'Separate capabilities for employees and administrators.',
-				icon: 'roles'
+				title: "Role-based consoles",
+				description: "Separate capabilities for employees and administrators.",
+				icon: "roles",
 			},
 			{
-				title: 'Admin management',
-				description: 'Manage clients, offices, employees, and assignments.',
-				icon: 'admin'
-			}
+				title: "Admin management",
+				description: "Manage clients, offices, employees, and assignments.",
+				icon: "admin",
+			},
 		],
 		steps: [
-			{ number: 1, title: 'Create or ingest', description: 'Add shipments into the system.' },
+			{
+				number: 1,
+				title: "Create or ingest",
+				description: "Add shipments into the system.",
+			},
 			{
 				number: 2,
-				title: 'Move through statuses',
-				description: 'Track across offices and status changes.'
+				title: "Move through statuses",
+				description: "Track across offices and status changes.",
 			},
 			{
 				number: 3,
-				title: 'Inspect the timeline',
-				description: 'Full accountability at every step.'
-			}
-		]
+				title: "Inspect the timeline",
+				description: "Full accountability at every step.",
+			},
+		],
 	};
 };


### PR DESCRIPTION
## Summary
Introduce the initial Hub API client foundation: a small client layer with request utilities + consistent error handling, plus the core types needed for entity interactions. Also adds a short integration guide and tightens CI/build/tooling so the client is easy to evolve without stepping on rakes.

## Changes
- Added infrastructure for a Hub API client with shared request helpers and built-in error handling.
- Introduced structured type definitions for entity interactions.
- Added documentation for Hub API integration (usage patterns + best practices).
- Enhanced CI to run automated tests.
- Updated build configuration and added dev dependencies for better tooling.
- Refined session type definitions for stricter type safety.

Closes: #34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Hub API client with typed request/response shapes, error normalization, DTOs and mappers to standardize server-side API interactions.

* **Documentation**
  * Added Hub API integration guide with usage patterns, forbidden patterns, and reviewer checklist.

* **Tests**
  * Added comprehensive unit tests covering auth, client behavior, response parsing, and error mapping.

* **Chores**
  * CI updated to run web tests; dev tooling updated (new dev dependency) and build/dev script adjustments.
* **Refactor**
  * Stricter session typing and auth source switched to session for server page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->