### PR TITLE
feat(hub-web): clients slice plumbing

### DIFF
--- a/logipack-hub/hub-api/src/dto/clients.rs
+++ b/logipack-hub/hub-api/src/dto/clients.rs
@@ -6,6 +6,8 @@ pub struct ClientDto {
     pub name: String,
     pub email: Option<String>,
     pub phone: Option<String>,
+
+    pub updated_at: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -17,7 +19,7 @@ pub struct CreateClientRequest {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateClientResponse {
-    pub client_id: String,
+    pub client: ClientDto,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -39,5 +41,5 @@ pub struct UpdateClientRequest {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateClientResponse {
-    pub client_id: String,
+    pub client: ClientDto,
 }

--- a/logipack-hub/hub-api/src/dto/shipments.rs
+++ b/logipack-hub/hub-api/src/dto/shipments.rs
@@ -3,7 +3,7 @@ use core_domain::shipment::ShipmentStatus;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::dto::clients::ClientDto;
+use crate::dto::{clients::ClientDto, offices::OfficeDto};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ShipmentListItem {
@@ -23,14 +23,6 @@ pub struct ShipmentDetail {
     pub current_office: Option<OfficeDto>,
     pub created_at: String,
     pub updated_at: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct OfficeDto {
-    pub id: String,
-    pub name: String,
-    pub city: String,
-    pub address: String,
 }
 
 #[derive(Deserialize)]
@@ -92,6 +84,7 @@ impl From<core_data::entity::shipments::Model> for ShipmentDetail {
                 name: "".to_string(),
                 email: None,
                 phone: None,
+                updated_at: value.updated_at.to_rfc3339(),
             },
             current_status: value.current_status,
             current_office: None,

--- a/logipack-hub/hub-api/src/routes/admin_ep/clients.rs
+++ b/logipack-hub/hub-api/src/routes/admin_ep/clients.rs
@@ -49,6 +49,7 @@ async fn list_clients_handler(
             name: client.name,
             phone: client.phone,
             email: client.email,
+            updated_at: client.updated_at.to_rfc3339(),
         })
         .collect();
 
@@ -91,6 +92,7 @@ async fn get_client_handler(
             name: client.name,
             phone: client.phone,
             email: client.email,
+            updated_at: client.updated_at.to_rfc3339(),
         },
     };
 
@@ -125,8 +127,29 @@ async fn create_client_handler(
             }
         })?;
 
+    let out = core_application::clients::get::get_client(&state.db, &actor, client_id)
+        .await
+        .map_err(|e| match e {
+            core_application::clients::get::GetClientError::NotFound => {
+                ApiError::not_found("client_not_found", "Client not found")
+            }
+            core_application::clients::get::GetClientError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::clients::get::GetClientError::ClientError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    let client = out.ok_or_else(|| ApiError::not_found("client_not_found", "Client not found"))?;
     let result = CreateClientResponse {
-        client_id: client_id.to_string(),
+        client: ClientDto {
+            id: client.id.to_string(),
+            name: client.name,
+            phone: client.phone,
+            email: client.email,
+            updated_at: client.updated_at.to_rfc3339(),
+        },
     };
 
     Ok((axum::http::StatusCode::CREATED, Json(result)))
@@ -153,7 +176,7 @@ async fn update_client_handler(
         email: request.email,
     };
 
-    let out = core_application::clients::update::update_client(&state.db, &actor, input)
+    let updated_id = core_application::clients::update::update_client(&state.db, &actor, input)
         .await
         .map_err(|e| match e {
             core_application::clients::update::UpdateClientError::NotFound => {
@@ -170,8 +193,29 @@ async fn update_client_handler(
             }
         })?;
 
+    let out = core_application::clients::get::get_client(&state.db, &actor, updated_id)
+        .await
+        .map_err(|e| match e {
+            core_application::clients::get::GetClientError::NotFound => {
+                ApiError::not_found("client_not_found", "Client not found")
+            }
+            core_application::clients::get::GetClientError::Forbidden => {
+                ApiError::forbidden("access_denied", "Access denied")
+            }
+            core_application::clients::get::GetClientError::ClientError(err) => {
+                ApiError::internal(err.to_string())
+            }
+        })?;
+
+    let client = out.ok_or_else(|| ApiError::not_found("client_not_found", "Client not found"))?;
     let result = UpdateClientResponse {
-        client_id: out.to_string(),
+        client: ClientDto {
+            id: client.id.to_string(),
+            name: client.name,
+            phone: client.phone,
+            email: client.email,
+            updated_at: client.updated_at.to_rfc3339(),
+        },
     };
 
     Ok(Json(result))

--- a/logipack-hub/hub-api/tests/clients/clients_create.rs
+++ b/logipack-hub/hub-api/tests/clients/clients_create.rs
@@ -39,9 +39,9 @@ async fn admin_can_create_client() {
     assert_eq!(res.status(), StatusCode::CREATED);
     let body = res.into_body().collect().await.unwrap().to_bytes();
     let body: CreateClientResponse = serde_json::from_slice(&body).unwrap();
-    let client_id = Uuid::parse_str(&body.client_id).unwrap();
+    let client = body.client;
 
-    assert_ne!(client_id, Uuid::nil());
+    assert_eq!(client.name, "John Doe");
 }
 
 #[tokio::test]

--- a/logipack-hub/hub-api/tests/clients/clients_update.rs
+++ b/logipack-hub/hub-api/tests/clients/clients_update.rs
@@ -42,8 +42,9 @@ async fn admin_can_update_client() {
 
     let body = res.into_body().collect().await.unwrap().to_bytes();
     let body: UpdateClientResponse = serde_json::from_slice(&body).unwrap();
+    let client = body.client;
 
-    assert_eq!(body.client_id, client_id.to_string());
+    assert_eq!(client.name, "Updated Client");
 }
 
 #[tokio::test]

--- a/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/clients.mapper.test.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/clients.mapper.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+	mapGetClientResponseDto,
+	mapListClientsResponseDto,
+} from "../mappers/clients";
+import { HubApiMappingError } from "../normalizers";
+
+describe("clients mappers", () => {
+	test("valid list payload maps correctly (optional email/phone)", () => {
+		const listDto = {
+			clients: [
+				{ id: "c1", name: "ACME", email: "a@b.com", phone: null },
+				{ id: "c2", name: "No Contact" }, // missing optionals ok
+			],
+		};
+
+		const items = mapListClientsResponseDto(listDto as any);
+		expect(items).toHaveLength(2);
+		expect(items[0]).toMatchObject({
+			id: "c1",
+			name: "ACME",
+			email: "a@b.com",
+			phone: null,
+		});
+		expect(items[1]).toMatchObject({ id: "c2", name: "No Contact" });
+	});
+
+	test("valid detail payload maps correctly (nullable fields)", () => {
+		const detailDto = {
+			client: {
+				id: "c1",
+				name: "ACME",
+				email: "contact@acme.com",
+				phone: "123",
+				created_at: "2026-03-02T12:00:00.000Z",
+				updated_at: "2026-03-02T12:30:00.000Z",
+				deleted_at: null,
+			},
+		};
+
+		const detail = mapGetClientResponseDto(detailDto as any);
+		expect(detail.id).toBe("c1");
+		expect(detail.deleted_at).toBeNull();
+		expect(detail.created_at).toBe("2026-03-02T12:00:00.000Z");
+	});
+
+	test("invalid required field types throw HubApiMappingError with context", () => {
+		const bad = { clients: [{ id: 123, name: "X" }] };
+
+		try {
+			mapListClientsResponseDto(bad as any);
+			throw new Error("expected mapper to throw");
+		} catch (e) {
+			expect(e).toBeInstanceOf(HubApiMappingError);
+			const err = e as HubApiMappingError;
+			expect(err.endpoint).toBe("GET /admin/clients");
+			expect(err.field).toContain("client.id");
+		}
+	});
+
+	test("nullable email/phone stable when present as whitespace", () => {
+		const detailDto = {
+			client: {
+				id: "c1",
+				name: "ACME",
+				email: "   ",
+				phone: "   ",
+			},
+		};
+
+		const detail = mapGetClientResponseDto(detailDto as any);
+		expect(detail.email).toBeNull();
+		expect(detail.phone).toBeNull();
+	});
+});

--- a/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/clients.service.test.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/__tests__/clients.service.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test";
+import { createHubApiClient } from "../httpClient";
+import { HubApiError } from "../errors";
+import {
+	listClients,
+	getClient,
+	createClient,
+	updateClient,
+	deleteClient,
+} from "../services/clients";
+
+function makeFetchMock(
+	fn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+) {
+	return fn as unknown as typeof fetch;
+}
+
+describe("clients service", () => {
+	test("listClients success", async () => {
+		const fetchMock = makeFetchMock(async (url, init) => {
+			expect(String(url)).toContain("/admin/clients");
+			expect(init?.method).toBe("GET");
+
+			return new Response(
+				JSON.stringify({
+					clients: [
+						{
+							id: "c1",
+							name: "ACME",
+							email: "contact@acme.com",
+							phone: null,
+							updated_at: "2026-03-02T12:43:00.000Z",
+						},
+					],
+				}),
+				{ status: 200 },
+			);
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: { access_token: "tok" } } as any,
+			baseUrl: "https://example.com",
+		});
+
+		const clients = await listClients(client);
+		expect(clients).toHaveLength(1);
+		expect(clients[0]!.id).toBe("c1");
+	});
+
+	test("getClient success", async () => {
+		const fetchMock = makeFetchMock(async (url, init) => {
+			expect(String(url)).toContain("/admin/clients/c1");
+			expect(init?.method).toBe("GET");
+
+			return new Response(
+				JSON.stringify({
+					client: {
+						id: "c1",
+						name: "ACME",
+						email: null,
+						phone: "+359888123456",
+						updated_at: "2026-03-02T12:43:00.000Z",
+						created_at: "2026-03-01T10:00:00.000Z",
+						deleted_at: null,
+					},
+				}),
+				{ status: 200 },
+			);
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: { access_token: "tok" } } as any,
+			baseUrl: "https://example.com",
+		});
+
+		const c = await getClient(client, "c1");
+		expect(c.id).toBe("c1");
+		expect(c.deleted_at).toBeNull();
+	});
+
+	test("createClient success", async () => {
+		const fetchMock = makeFetchMock(async (url, init) => {
+			expect(String(url)).toContain("/admin/clients");
+			expect(init?.method).toBe("POST");
+
+			const headers = init!.headers as Record<string, string>;
+			expect(headers["Content-Type"]).toBe("application/json");
+			expect(init!.body).toBe(
+				JSON.stringify({ name: "Nova", email: null, phone: null }),
+			);
+
+			return new Response(
+				JSON.stringify({
+					client: {
+						id: "c2",
+						name: "Nova",
+						email: null,
+						phone: null,
+						updated_at: "2026-03-02T12:43:00.000Z",
+					},
+				}),
+				{ status: 201 },
+			);
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: { access_token: "tok" } } as any,
+			baseUrl: "https://example.com",
+		});
+
+		const created = await createClient(client, {
+			name: "Nova",
+			email: null,
+			phone: null,
+		});
+		expect(created.id).toBe("c2");
+		expect(created.name).toBe("Nova");
+	});
+
+	test("updateClient success", async () => {
+		const fetchMock = makeFetchMock(async (url, init) => {
+			expect(String(url)).toContain("/admin/clients/c1");
+			expect(init?.method).toBe("PUT");
+
+			return new Response(
+				JSON.stringify({
+					client: {
+						id: "c1",
+						name: "ACME Updated",
+						email: "new@acme.com",
+						phone: null,
+						updated_at: "2026-03-02T13:43:00.000Z",
+					},
+				}),
+				{ status: 200 },
+			);
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: { access_token: "tok" } } as any,
+			baseUrl: "https://example.com",
+		});
+
+		const updated = await updateClient(client, "c1", {
+			name: "ACME Updated",
+			email: "new@acme.com",
+			phone: null,
+		});
+		expect(updated.name).toBe("ACME Updated");
+	});
+
+	test("deleteClient success (204)", async () => {
+		const fetchMock = makeFetchMock(async (url, init) => {
+			expect(String(url)).toContain("/admin/clients/c1");
+			expect(init?.method).toBe("DELETE");
+			return new Response(null, { status: 204 });
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: { access_token: "tok" } } as any,
+			baseUrl: "https://example.com",
+		});
+
+		await deleteClient(client, "c1");
+	});
+
+	test("error propagation: 404 -> HubApiError", async () => {
+		const fetchMock = makeFetchMock(async () => {
+			return new Response("", { status: 404 });
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: { access_token: "tok" } } as any,
+			baseUrl: "https://example.com",
+		});
+
+		await expect(getClient(client, "missing")).rejects.toBeInstanceOf(
+			HubApiError,
+		);
+	});
+
+	test("error propagation: 400 JSON -> HubApiError", async () => {
+		const fetchMock = makeFetchMock(async () => {
+			return new Response(
+				JSON.stringify({ code: "BAD_INPUT", message: "nope" }),
+				{
+					status: 400,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: { access_token: "tok" } } as any,
+			baseUrl: "https://example.com",
+		});
+
+		await expect(
+			createClient(client, { name: "", email: null, phone: null }),
+		).rejects.toBeInstanceOf(HubApiError);
+	});
+
+	test("error propagation: 500 -> HubApiError", async () => {
+		const fetchMock = makeFetchMock(async () => {
+			return new Response("boom", { status: 500 });
+		});
+
+		const client = createHubApiClient({
+			fetch: fetchMock,
+			locals: { session: { access_token: "tok" } } as any,
+			baseUrl: "https://example.com",
+		});
+
+		await expect(listClients(client)).rejects.toBeInstanceOf(HubApiError);
+	});
+});

--- a/logipack-hub/hub-web/src/lib/server/hubApi/dto/clients.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/dto/clients.ts
@@ -1,4 +1,48 @@
-import type { UnknownDto } from "./common";
+export type ClientDto = {
+	id: string;
+	name: string;
 
-export type ClientListItemDto = UnknownDto;
-export type ClientDetailDto = UnknownDto;
+	email?: string | null;
+	phone?: string | null;
+
+	createdAt?: string | null;
+	updatedAt?: string | null;
+	deletedAt?: string | null;
+};
+
+export type ClientListItemDto = {
+	id: string;
+	name: string;
+	email?: string | null;
+	phone?: string | null;
+
+	updated_at?: string | null;
+};
+
+export type ListClientsResponseDto = {
+	clients: ClientListItemDto[];
+};
+
+export type GetClientResponseDto = {
+	client: ClientDto;
+};
+
+export type CreateClientRequestDto = {
+	name: string;
+	email?: string | null;
+	phone?: string | null;
+};
+
+export type CreateClientResponseDto = {
+	client: ClientDto;
+};
+
+export type UpdateClientRequestDto = {
+	name?: string | null;
+	email?: string | null;
+	phone?: string | null;
+};
+
+export type UpdateClientResponseDto = {
+	client: ClientDto;
+};

--- a/logipack-hub/hub-web/src/lib/server/hubApi/mappers/clients.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/mappers/clients.ts
@@ -1,16 +1,214 @@
-import type { ClientListItemDto, ClientDetailDto } from "../dto/clients";
+import type {
+	ClientDto,
+	ClientListItemDto,
+	ListClientsResponseDto,
+	GetClientResponseDto,
+	CreateClientResponseDto,
+	UpdateClientResponseDto,
+} from "../dto/clients";
+import {
+	requireIsoDateTime,
+	requireRecord,
+	requireString,
+	cleanNullableString,
+	HubApiMappingError,
+} from "../normalizers";
 
-export type ClientListItem = Record<string, never>;
-export type ClientDetail = Record<string, never>;
+/**
+ * App-safe shapes used by UI
+ */
+export type ClientListItem = {
+	id: string;
+	name: string;
+	email?: string | null;
+	phone?: string | null;
+	updated_at?: string;
+};
 
-export function mapClientListItemDtoToClientListItem(
-	_dto: ClientListItemDto,
-): ClientListItem {
-	return {};
+export type ClientDetail = {
+	id: string;
+	name: string;
+	email?: string | null;
+	phone?: string | null;
+
+	created_at?: string;
+	updated_at?: string;
+	deleted_at?: string | null;
+};
+
+export function mapClientBase(args: {
+	endpoint: string;
+	obj: Record<string, unknown>;
+}): {
+	id: string;
+	name: string;
+	email?: string | null;
+	phone?: string | null;
+} {
+	const { endpoint, obj } = args;
+
+	const email =
+		obj.email === undefined
+			? undefined
+			: cleanNullableString({
+				endpoint,
+				field: "client.email",
+				value: obj.email,
+			});
+
+	const phone =
+		obj.phone === undefined
+			? undefined
+			: cleanNullableString({
+				endpoint,
+				field: "client.phone",
+				value: obj.phone,
+			});
+
+	return {
+		id: requireString({
+			endpoint,
+			field: "client.id",
+			value: obj.id,
+			nonEmpty: true,
+		}),
+		name: requireString({
+			endpoint,
+			field: "client.name",
+			value: obj.name,
+			nonEmpty: true,
+		}),
+		...(email !== undefined ? { email } : {}),
+		...(phone !== undefined ? { phone } : {}),
+	};
 }
 
-export function mapClientDetailDtoToClientDetail(
-	_dto: ClientDetailDto,
+export function mapClientListItemDtoToClientListItem(
+	dto: ClientListItemDto,
+): ClientListItem {
+	const endpoint = "GET /admin/clients";
+	const obj = requireRecord({ endpoint, field: "client", value: dto });
+
+	const base = mapClientBase({ endpoint, obj });
+
+	const updated_at =
+		obj.updated_at === undefined || obj.updated_at === null
+			? undefined
+			: requireIsoDateTime({
+				endpoint,
+				field: "client.updated_at",
+				value: obj.updated_at,
+			});
+
+	return {
+		...base,
+		...(updated_at ? { updated_at } : {}),
+	};
+}
+
+export function mapClientDtoToClientDetail(dto: ClientDto): ClientDetail {
+	const endpoint = "GET /admin/clients/:id";
+	const obj = requireRecord({ endpoint, field: "client", value: dto });
+
+	const base = mapClientBase({ endpoint, obj });
+
+	const created_at =
+		obj.created_at === undefined || obj.created_at === null
+			? undefined
+			: requireIsoDateTime({
+				endpoint,
+				field: "client.created_at",
+				value: obj.created_at,
+			});
+
+	const updated_at =
+		obj.updated_at === undefined || obj.updated_at === null
+			? undefined
+			: requireIsoDateTime({
+				endpoint,
+				field: "client.updated_at",
+				value: obj.updated_at,
+			});
+
+	const deleted_at =
+		obj.deleted_at === undefined
+			? undefined
+			: cleanNullableString({
+				endpoint,
+				field: "client.deleted_at",
+				value: obj.deleted_at,
+			});
+
+	return {
+		...base,
+		...(created_at ? { created_at } : {}),
+		...(updated_at ? { updated_at } : {}),
+		...(deleted_at !== undefined ? { deleted_at } : {}),
+	};
+}
+
+export function mapListClientsResponseDto(
+	dto: ListClientsResponseDto,
+): ClientListItem[] {
+	const endpoint = "GET /admin/clients";
+	const obj = requireRecord({ endpoint, field: "response", value: dto });
+
+	if (!Array.isArray(obj.clients)) {
+		throw new HubApiMappingError({
+			endpoint,
+			field: "clients",
+			message: "expected clients[]",
+		});
+	}
+
+	return obj.clients.map((c, i) =>
+		mapClientListItemDtoToClientListItem(
+			requireRecord({ endpoint, field: `clients[${i}]`, value: c }) as any,
+		),
+	);
+}
+
+export function mapGetClientResponseDto(
+	dto: GetClientResponseDto,
 ): ClientDetail {
-	return {};
+	const endpoint = "GET /admin/clients/:id";
+	const obj = requireRecord({ endpoint, field: "response", value: dto });
+
+	return mapClientDtoToClientDetail(
+		requireRecord({
+			endpoint,
+			field: "client",
+			value: obj.client,
+		}) as any,
+	);
+}
+
+export function mapCreateClientResponseDto(
+	dto: CreateClientResponseDto,
+): ClientDetail {
+	const endpoint = "POST /admin/clients";
+	const obj = requireRecord({ endpoint, field: "response", value: dto });
+
+	return mapClientDtoToClientDetail(
+		requireRecord({
+			endpoint,
+			field: "client",
+			value: obj.client,
+		}) as any,
+	);
+}
+
+export function mapUpdateClientResponseDto(
+	dto: UpdateClientResponseDto,
+): ClientDetail {
+	const endpoint = "PUT /admin/clients/:id";
+	const obj = requireRecord({ endpoint, field: "response", value: dto });
+
+	return mapClientDtoToClientDetail(
+		requireRecord({
+			endpoint,
+			field: "client",
+			value: obj.client,
+		}) as any,
+	);
 }

--- a/logipack-hub/hub-web/src/lib/server/hubApi/services/clients.ts
+++ b/logipack-hub/hub-web/src/lib/server/hubApi/services/clients.ts
@@ -1,0 +1,73 @@
+import type { HubApiClient } from "../index";
+import type {
+	CreateClientRequestDto,
+	CreateClientResponseDto,
+	GetClientResponseDto,
+	ListClientsResponseDto,
+	UpdateClientRequestDto,
+	UpdateClientResponseDto,
+} from "../dto/clients";
+import type { ClientDetail, ClientListItem } from "../mappers/clients";
+import {
+	mapCreateClientResponseDto,
+	mapGetClientResponseDto,
+	mapListClientsResponseDto,
+	mapUpdateClientResponseDto,
+} from "../mappers/clients";
+
+export async function listClients(
+	client: HubApiClient,
+	timeoutMs = 10_000,
+): Promise<ClientListItem[]> {
+	const res = await client.get<ListClientsResponseDto>("/admin/clients", {
+		timeoutMs,
+	});
+	return mapListClientsResponseDto(res.data);
+}
+
+export async function getClient(
+	client: HubApiClient,
+	clientId: string,
+	timeoutMs = 10_000,
+): Promise<ClientDetail> {
+	const res = await client.get<GetClientResponseDto>(
+		`/admin/clients/${clientId}`,
+		{ timeoutMs },
+	);
+	return mapGetClientResponseDto(res.data);
+}
+
+export async function createClient(
+	client: HubApiClient,
+	payload: CreateClientRequestDto,
+	timeoutMs = 10_000,
+): Promise<ClientDetail> {
+	const res = await client.post<CreateClientResponseDto>(
+		"/admin/clients",
+		payload,
+		{ timeoutMs },
+	);
+	return mapCreateClientResponseDto(res.data);
+}
+
+export async function updateClient(
+	client: HubApiClient,
+	clientId: string,
+	payload: UpdateClientRequestDto,
+	timeoutMs = 10_000,
+): Promise<ClientDetail> {
+	const res = await client.put<UpdateClientResponseDto>(
+		`/admin/clients/${clientId}`,
+		payload,
+		{ timeoutMs },
+	);
+	return mapUpdateClientResponseDto(res.data);
+}
+
+export async function deleteClient(
+	client: HubApiClient,
+	clientId: string,
+	timeoutMs = 10_000,
+): Promise<void> {
+	await client.delete(`/admin/clients/${clientId}`, { timeoutMs });
+}

--- a/logipack-hub/hub-web/src/routes/[lang]/app/admin/clients/+page.server.ts
+++ b/logipack-hub/hub-web/src/routes/[lang]/app/admin/clients/+page.server.ts
@@ -1,31 +1,57 @@
+import { HUB_API_BASE } from "$env/static/private";
+import { createHubApiClient, HubApiError } from "$lib/server/hubApi";
+import { listClients } from "$lib/server/hubApi/services/clients";
 import type { PageServerLoad } from "./$types";
-import {
-	filterMockClientsByQuery,
-	listMockClients,
-} from "$lib/server/mockClients";
 
-type ClientListItem = {
-	id: string;
-	name: string;
-	email?: string | null;
-	phone?: string | null;
-};
+function filterByQuery<
+	T extends {
+		id?: string;
+		name: string;
+		email?: string | null;
+		phone?: string | null;
+	},
+>(items: T[], q: string): T[] {
+	const needle = q.toLowerCase();
+	if (!needle) {
+		return items;
+	}
 
-async function fetchAdminClients(q: string): Promise<ClientListItem[]> {
-	// TODO(api): replace mock with hub-api GET /admin/clients
-	return filterMockClientsByQuery(listMockClients(), q);
+	return items.filter((item) => {
+		`${item.id ?? ""}${item.name}${item.email ?? ""}${item.phone ?? ""}`
+			.toLowerCase()
+			.includes(needle);
+	});
 }
 
-export const load: PageServerLoad = async ({ url }) => {
+export const load: PageServerLoad = async ({ url, fetch, locals }) => {
 	const q = url.searchParams.get("q")?.trim() ?? "";
 
 	try {
+		const client = createHubApiClient({
+			fetch,
+			locals,
+			baseUrl: HUB_API_BASE,
+		});
+
+		const clients = await listClients(client);
+
 		return {
-			clients: await fetchAdminClients(q),
+			clients: filterByQuery(clients, q),
 			q,
 			loadError: false,
 		};
-	} catch {
+	} catch (e) {
+		if (e instanceof HubApiError) {
+			console.error("admin.clients.list failed", {
+				status: e.status,
+				code: e.code,
+				message: e.message,
+				upstream: e.upstream,
+			});
+		} else {
+			console.error("admin.clients.list failed", e);
+		}
+
 		return {
 			clients: [],
 			q,

--- a/logipack-hub/hub-web/src/routes/[lang]/app/admin/clients/[id]/+page.server.ts
+++ b/logipack-hub/hub-web/src/routes/[lang]/app/admin/clients/[id]/+page.server.ts
@@ -1,71 +1,82 @@
-import { deleteMockClient, getMockClientById } from "$lib/server/mockClients";
-import { fail, redirect } from "@sveltejs/kit";
-import type { Actions, PageServerLoad } from "./$types";
-
-type ClientDetail = {
-	id: string;
-	name: string;
-	email: string | null;
-	phone: string | null;
-	updated_at: string;
-};
+import { HUB_API_BASE } from "$env/static/private";
+import { createHubApiClient, HubApiError } from "$lib/server/hubApi";
+import { getClient } from "$lib/server/hubApi/services/clients";
+import { fail, isRedirect, redirect, type Actions } from "@sveltejs/kit";
+import type { PageServerLoad } from "./$types";
 
 type DetailResult =
-	| { state: "ok"; client: ClientDetail }
-	| { state: "not_found" }
-	| { state: "error"; message: string };
-
-function fetchClientDetail(id: string): DetailResult {
-	// TODO(api): replace mock with hub-api GET /admin/clients/:id
-	const client = getMockClientById(id);
-	if (!client) {
-		return { state: "not_found" };
+	| {
+		state: "ok";
+		client: Awaited<ReturnType<typeof getClient>>;
 	}
-
-	return {
-		state: "ok",
-		client: {
-			id: client.id,
-			name: client.name,
-			email: client.email,
-			phone: client.phone,
-			updated_at: client.updated_at,
-		},
+	| {
+		state: "not_found";
+	}
+	| {
+		state: "error";
+		message: string;
 	};
-}
 
-export const load: PageServerLoad = async ({ params }) => {
+export const load: PageServerLoad = async ({ params, fetch, locals }) => {
 	try {
-		return { result: fetchClientDetail(params.id) };
-	} catch (error) {
-		console.error("admin.clients.detail.load_failed", {
-			clientId: params.id,
-			error,
+		const client = createHubApiClient({
+			fetch,
+			locals,
+			baseUrl: HUB_API_BASE,
 		});
+		const detail = await getClient(client, params.id);
+
+		return { result: { state: "ok", client: detail } satisfies DetailResult };
+	} catch (e) {
+		if (e instanceof HubApiError && e.status === 404) {
+			return { result: { state: "not_found" } satisfies DetailResult };
+		}
+
+		if (e instanceof HubApiError) {
+			console.error("admin.clients.detail failed", {
+				clientId: params.id,
+				status: e.status,
+				code: e.code,
+				message: e.message,
+				upstream: e.upstream,
+			});
+		} else {
+			console.error("admin.clients.detail failed", {
+				clientId: params.id,
+				error: e,
+			});
+		}
+
 		return {
 			result: {
-				state: "error" as const,
+				state: "error",
 				message: "admin.clients.detail.load_failed",
-			},
+			} satisfies DetailResult,
 		};
 	}
 };
 
 export const actions: Actions = {
-	delete: async ({ params }) => {
+	delete: async ({ params, fetch, locals }) => {
 		try {
-			const deleted = deleteMockClient(params.id);
-			if (!deleted) {
-				return fail(404, {
-					submitError: "admin.clients.detail.not_found",
-				});
-			}
-		} catch {
-			return fail(500, {
-				submitError: "admin.clients.detail.delete_failed",
+			const client = createHubApiClient({
+				fetch,
+				locals,
+				baseUrl: HUB_API_BASE,
 			});
-		}
+			await client.delete(`/admin/clients/${params.id}`);
 
-		throw redirect(303, `/${params.lang ?? "en"}/app/admin/clients`);
+			throw redirect(303, `/${params.lang ?? "en"}/admin/clients`);
+		} catch (e) {
+			if (isRedirect(e)) {
+				throw e;
+			}
+
+			if (e instanceof HubApiError && e.status === 404) {
+				return fail(404, { submitError: "admin.clients.detail.not_found " });
+			}
+
+			return fail(500, { submitError: "admin.clients.detail.delete_failed" });
+		}
 	},
 };

--- a/logipack-hub/hub-web/src/routes/[lang]/app/admin/clients/[id]/edit/+page.server.ts
+++ b/logipack-hub/hub-web/src/routes/[lang]/app/admin/clients/[id]/edit/+page.server.ts
@@ -1,42 +1,58 @@
-import { getMockClientById, updateMockClient } from "$lib/server/mockClients";
+import { HUB_API_BASE } from "$env/static/private";
+import { createHubApiClient, HubApiError } from "$lib/server/hubApi";
+import { getClient, updateClient } from "$lib/server/hubApi/services/clients";
+import { fail, isRedirect, redirect, type Actions } from "@sveltejs/kit";
+import type { PageServerLoad } from "../$types";
 import {
 	hasClientFormErrors,
 	parseClientFormData,
 	validateClientForm,
 } from "$lib/server/clientForm";
-import { fail, redirect } from "@sveltejs/kit";
-import type { Actions, PageServerLoad } from "./$types";
 
-const EMPTY_VALUES = {
+const EMPTY_VALUE = {
 	name: "",
 	email: null,
 	phone: null,
 };
 
-export const load: PageServerLoad = async ({ params }) => {
-	// TODO(api): replace mock with hub-api GET /admin/clients/:id
-	const client = getMockClientById(params.id);
-	if (!client) {
+export const load: PageServerLoad = async ({ params, fetch, locals }) => {
+	try {
+		const client = createHubApiClient({
+			fetch,
+			locals,
+			baseUrl: HUB_API_BASE,
+		});
+		const detail = await getClient(client, params.id);
+
+		return {
+			clientId: detail.id,
+			notFound: false as const,
+			initialValues: {
+				name: detail.name,
+				email: detail.email ?? null,
+				phone: detail.phone ?? null,
+			},
+		};
+	} catch (e) {
+		if (e instanceof HubApiError && e.status === 404) {
+			return {
+				clientId: params.id,
+				notFound: true as const,
+				initialValues: EMPTY_VALUE,
+			};
+		}
+
+		console.error("admin.clients.edit.load_failed", { clientId: params.id, e });
 		return {
 			clientId: params.id,
-			notFound: true as const,
-			initialValues: EMPTY_VALUES,
+			notFound: false as const,
+			initialValues: EMPTY_VALUE,
 		};
 	}
-
-	return {
-		clientId: client.id,
-		notFound: false as const,
-		initialValues: {
-			name: client.name,
-			email: client.email,
-			phone: client.phone,
-		},
-	};
 };
 
 export const actions: Actions = {
-	default: async ({ request, params }) => {
+	default: async ({ request, params, fetch, locals }) => {
 		const values = parseClientFormData(await request.formData());
 		const fieldErrors = validateClientForm(values);
 
@@ -45,23 +61,50 @@ export const actions: Actions = {
 		}
 
 		try {
-			// TODO(api): replace mock update with hub-api PUT/PATCH /admin/clients/:id
-			const updatedClient = updateMockClient(params.id, values);
-			if (!updatedClient) {
-				return fail(404, {
-					fieldErrors: {},
-					submitError: "admin.clients.detail.not_found",
-					values,
-				});
+			const client = createHubApiClient({
+				fetch,
+				locals,
+				baseUrl: HUB_API_BASE,
+			});
+
+			await updateClient(client, params.id!, {
+				name: values.name,
+				email: values.email,
+				phone: values.phone,
+			});
+
+			throw redirect(
+				303,
+				`/${params.lang ?? "en"}/app/admin/clients/${params.id}`,
+			);
+		} catch (e) {
+			if (isRedirect(e)) {
+				throw e;
 			}
-		} catch {
+
+			if (e instanceof HubApiError) {
+				if (e.status === 404) {
+					return fail(404, {
+						fieldErrors: {},
+						submitError: "admin.clients.detail.not_found",
+						values,
+					});
+				}
+
+				if (e.status === 400) {
+					return fail(400, {
+						fieldErrors: {},
+						submitError: "admin.clients.edit.submit_failed",
+						values,
+					});
+				}
+			}
+
 			return fail(500, {
 				fieldErrors: {},
 				submitError: "admin.clients.edit.submit_failed",
 				values,
 			});
 		}
-
-		redirect(303, `/${params.lang ?? "en"}/app/admin/clients/${params.id}`);
 	},
 };

--- a/logipack-hub/hub-web/src/routes/[lang]/app/admin/clients/new/+page.server.ts
+++ b/logipack-hub/hub-web/src/routes/[lang]/app/admin/clients/new/+page.server.ts
@@ -1,14 +1,15 @@
-import { createMockClient } from "$lib/server/mockClients";
+import { HUB_API_BASE } from "$env/static/private";
 import {
 	hasClientFormErrors,
 	parseClientFormData,
 	validateClientForm,
 } from "$lib/server/clientForm";
-import { fail, redirect } from "@sveltejs/kit";
-import type { Actions } from "./$types";
+import { createHubApiClient, HubApiError } from "$lib/server/hubApi";
+import { createClient } from "$lib/server/hubApi/services/clients";
+import { fail, isRedirect, redirect, type Actions } from "@sveltejs/kit";
 
 export const actions: Actions = {
-	default: async ({ request, params }) => {
+	default: async ({ request, params, fetch, locals }) => {
 		const values = parseClientFormData(await request.formData());
 		const fieldErrors = validateClientForm(values);
 
@@ -16,19 +17,41 @@ export const actions: Actions = {
 			return fail(400, { fieldErrors, values });
 		}
 
-		let clientId: string;
 		try {
-			// TODO(api): replace mock create with hub-api POST /admin/clients
-			const { id } = createMockClient(values);
-			clientId = id;
-		} catch {
+			const client = createHubApiClient({
+				fetch,
+				locals,
+				baseUrl: HUB_API_BASE,
+			});
+
+			const created = await createClient(client, {
+				name: values.name,
+				email: values.email,
+				phone: values.phone,
+			});
+
+			throw redirect(
+				303,
+				`${params.lang ?? "en"}/app/admin/clients/${created.id}`,
+			);
+		} catch (e) {
+			if (isRedirect(e)) {
+				throw e;
+			}
+
+			if (e instanceof HubApiError && e.status === 400) {
+				return fail(400, {
+					fieldErrors: {},
+					submitError: "admin.clients.new.submit_failed",
+					values,
+				});
+			}
+
 			return fail(500, {
 				fieldErrors: {},
 				submitError: "admin.clients.new.submit_failed",
 				values,
 			});
 		}
-
-		throw redirect(303, `/${params.lang ?? "en"}/app/admin/clients/${clientId}`);
 	},
 };


### PR DESCRIPTION
## Summary
Replace admin Clients mock flows with real `hub-api` CRUD integration and finalize client contracts end-to-end, including backend DTO response shapes and frontend hubApi DTO/mapper/service + tests.

## Changes
- **hub-api**
  - Extend `ClientDto` to include `updated_at`.
  - Change client mutation responses to return full `client` object instead of just `client_id` (create/update).
  - Populate `updated_at` in list/get responses and in shipment client placeholder mapping.
  - Update client create/update integration tests to assert returned client fields.

- **hub-web**
  - Finalize `hubApi` clients DTOs and mappers with strict shape validation + nullable `email`/`phone` handling.
  - Add `hubApi/services/clients.ts` (list/get/create/update/delete) using shared client + mappers; treat `204` delete as success.
  - Rewire admin clients list/detail/new/edit routes to call `hub-api` via shared `createHubApiClient` (no UI redesign).
  - Add mapper + service test suites for clients.

- **Notes**
  - Keeps existing page state shapes (`ok/empty/error/not_found`) and action failure shapes (`fieldErrors`, `submitError`, `values`) intact.
  - Removes reliance on `mockClients` for admin client CRUD.

Closes #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Client management now uses real API integration instead of mock data for all operations.
  * API responses for client operations now return complete client details including timestamps.

* **Refactor**
  * Restructured client response payloads to include full client objects with metadata instead of IDs only.
  * Enhanced data validation and error handling across client-related endpoints.

* **Tests**
  * Added comprehensive test coverage for client API mappers and service interactions.
  * Updated test suite to validate new response structures and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->